### PR TITLE
Method description is not being included

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -156,7 +156,7 @@
             <% end %>
           </div>
           
-          <% unless method.comment %>
+          <% if method.comment %>
             <div class="description">
               <%= method.description.strip %>
             </div>

--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -156,7 +156,7 @@
             <% end %>
           </div>
           
-          <% unless method.comment %>
+          <% if method.comment %>
             <div class="description">
               <%= method.description.strip %>
             </div>


### PR DESCRIPTION
Hi

please check that the clause:

<% unless method.comment %>

should be

<% if method.comment %>

I've changed in both sdoc and rails templates.
