### PR TITLE
Keep browser defaults for focused elements

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/reset.css
+++ b/lib/rdoc/generator/template/rails/resources/css/reset.css
@@ -33,11 +33,6 @@ q:before, q:after {
 	content: none;
 }
 
-/* remember to define focus styles! */
-:focus {
-	outline: 0;
-}
-
 /* remember to highlight inserts somehow! */
 ins {
 	text-decoration: none;

--- a/lib/rdoc/generator/template/sdoc/resources/css/reset.css
+++ b/lib/rdoc/generator/template/sdoc/resources/css/reset.css
@@ -33,11 +33,6 @@ q:before, q:after {
 	content: none;
 }
 
-/* remember to define focus styles! */
-:focus {
-	outline: 0;
-}
-
 /* remember to highlight inserts somehow! */
 ins {
 	text-decoration: none;


### PR DESCRIPTION
Improves accessibility, doesn't really ugly up the design. Could redefine a:focus, input:focus in the themes but there's no real advantage to reseting it globally anyway.
