### PR TITLE
Main page can be top-level class e.g. --main ::Widget

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -366,15 +366,11 @@ class RDoc::Generator::SDoc
     default = @files.first.path
     return default unless @options.main_page
 
-    main_page = @options.main_page.dup
-
     # Transform class name to file path
-    if main_page.include?("::")
-      slashed = main_page.sub(/^::/, "").gsub("::", "/")
-      main_page = "%s/%s.html" % [ class_dir, slashed ]
-    end
-
-    if file = @files.find { |f| f.full_name == main_page }
+    if @options.main_page.include?("::")
+      slashed = @options.main_page.sub(/^::/, "").gsub("::", "/")
+      "%s/%s.html" % [ class_dir, slashed ]
+    elsif file = @files.find { |f| f.full_name == @options.main_page }
       file.path
     else
       default


### PR DESCRIPTION
Pull request #21 by @Nerdmaster made it possible to specify a classname as the main page, instead of a file path, e.g. `--main Widget::Default`.

However this only works if the classname contains "::", so `--main Widget` does not work.

This patch makes it possible to specify `--main ::Widget` while still allowing `--main Widget::Default`.

Cheers!
Paul
