### PR TITLE
get rid of deprecation message

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -3,7 +3,7 @@ require 'erb'
 require 'pathname'
 require 'fileutils'
 require 'rdoc/markup/to_html'
-if Gem.available? "json"
+if Gem::Specification.respond_to?(:find_by_name) ? Gem::Specification::find_by_name("json") : Gem.available?("json")
   gem "json", ">= 1.1.3"
 else
   gem "json_pure", ">= 1.1.3"


### PR DESCRIPTION
NOTE: Gem.available? is deprecated, use Specification::find_by_name. It will be removed on or after 2011-11-01
