### PR TITLE
SEARCH_INDEX_FILE constant missing

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -109,6 +109,7 @@ class RDoc::Generator::SDoc
   GENERATOR_DIRS = [File.join('sdoc', 'generator')]
 
   TREE_FILE = File.join 'panel', 'tree.js'
+  SEARCH_INDEX_FILE = File.join 'js', 'search_index.js'
 
   FILE_DIR = 'files'
   CLASS_DIR = 'classes'


### PR DESCRIPTION
The `SEARCH_INDEX_FILE` constant had been removed but was still referenced in `merge.rb.`
This caused `$ sdoc-merge` to fail.

I really appreciate this gem, thank you!
