### PR TITLE
Start preliminary work on RDoc 4 support

### DIFF
--- a/lib/rdoc/discover.rb
+++ b/lib/rdoc/discover.rb
@@ -1,5 +1,5 @@
 begin
-  gem 'rdoc', '~> 3'
+  gem 'rdoc', '~> 4.0.0.rc'
   require File.join(File.dirname(__FILE__), '/../sdoc')
 rescue Gem::LoadError
 end

--- a/lib/sdoc.rb
+++ b/lib/sdoc.rb
@@ -1,7 +1,7 @@
 $:.unshift File.dirname(__FILE__)
 require "rubygems"
-gem 'rdoc', '~> 3'
+gem 'rdoc', '~> 4.0.0.rc'
 
 module SDoc end
-  
+
 require 'sdoc/generator'

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -120,6 +120,11 @@ class RDoc::Generator::SDoc
 
   attr_reader :options
 
+  ##
+  # The RDoc::Store that is the source of the generated content
+
+  attr_reader :store
+
   def self.setup_options(options)
     @github = false
     options.se_index = true
@@ -148,7 +153,8 @@ class RDoc::Generator::SDoc
 
   end
 
-  def initialize(options)
+  def initialize(store, options)
+    @store   = store
     @options = options
     if @options.respond_to?('diagram=')
       @options.diagram = false
@@ -161,15 +167,15 @@ class RDoc::Generator::SDoc
     @json_index = RDoc::Generator::JsonIndex.new self, options
   end
 
-  def generate(top_levels)
+  def generate
     @outputdir = Pathname.new(@options.op_dir).expand_path(@base_dir)
-    @files = top_levels.sort
-    @classes = RDoc::TopLevel.all_classes_and_modules.sort
+    @files = @store.all_files.sort
+    @classes = @store.all_classes_and_modules.sort
 
     # Now actually write the output
     copy_resources
     generate_class_tree
-    @json_index.generate top_levels
+    @json_index.generate
     generate_file_files
     generate_class_files
     generate_index_file

--- a/lib/sdoc/github.rb
+++ b/lib/sdoc/github.rb
@@ -2,7 +2,7 @@ module SDoc::GitHub
   def github_url(path)
     unless @github_url_cache.has_key? path
       @github_url_cache[path] = false
-      file = RDoc::TopLevel.find_file_named(path)
+      file = @store.find_file_named(path)
       if file
         base_url = repository_url(path)
         if base_url
@@ -16,7 +16,7 @@ module SDoc::GitHub
     end
     @github_url_cache[path]
   end
-  
+
   protected
 
   def have_git?
@@ -33,7 +33,7 @@ module SDoc::GitHub
     m = s.match(/commit\s+(\S+)/)
     m ? m[1] : false
   end
-  
+
   def repository_url(path)
     return false unless have_git?
     s = Dir.chdir(File.join(base_dir, File.dirname(path))) do
@@ -51,7 +51,7 @@ module SDoc::GitHub
 
   def path_to_git_dir(path)
     while !path.empty? && path != '.'
-      if (File.exists? File.join(path, '.git')) 
+      if (File.exists? File.join(path, '.git'))
         return path
       end
       path = File.dirname(path)

--- a/lib/sdoc/templatable.rb
+++ b/lib/sdoc/templatable.rb
@@ -20,7 +20,7 @@ module SDoc::Templatable
         ], err.backtrace
       end
   end
-  
+
   ### Load and render the erb template with the given +template_name+ within
   ### current context. Adds all +local_assigns+ to context
   def include_template(template_name, local_assigns = {})
@@ -28,13 +28,13 @@ module SDoc::Templatable
     templatefile = @template_dir + template_name
     eval("#{source};eval_template(templatefile, binding)")
   end
-  
+
 	### Load and render the erb template in the given +templatefile+ within the
 	### specified +context+ (a Binding object) and write it out to +outfile+.
 	### Both +templatefile+ and +outfile+ should be Pathname-like objects.
 	def render_template( templatefile, context, outfile )
     output = eval_template(templatefile, context)
-    
+
     # TODO delete this dirty hack when documentation for example for GeneratorMethods will not be cutted off by <script> tag
     begin
       if output.respond_to? :force_encoding
@@ -44,9 +44,9 @@ module SDoc::Templatable
         output = output.gsub('<script>', '&lt;script&gt;')
       end
     rescue Exception => e
-      
+
     end
-    
+
 		unless $dryrun
 			outfile.dirname.mkpath
 			outfile.open( 'w', 0644 ) do |file|
@@ -56,5 +56,5 @@ module SDoc::Templatable
 			debug_msg "  would have written %d bytes to %s" %
 			[ output.length, outfile ]
 		end
-	end  
+	end
 end

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -2,9 +2,9 @@
 
 Gem::Specification.new do |s|
   s.name = "sdoc"
-  s.version = "0.3.20"
+  s.version = "0.4.0"
 
-  s.authors = ["Vladimir Kolesnikov", "Nathan Broadbent"]
+  s.authors = ["Vladimir Kolesnikov", "Nathan Broadbent", "Jean Mertz"]
   s.description = %q{rdoc generator html with javascript search index.}
   s.summary = %q{rdoc html with javascript search index.}
   s.homepage = %q{http://github.com/voloko/sdoc}


### PR DESCRIPTION
I wanted to use the Markdown parser in RDoc 4, but don't like the default templates. So I updated SDoc to work with RDoc 4. These are the bare minimum required changes to make the generator pass without errors. Some things don't work (correctly) yet:
- [ ] Github link now showing up
- [ ] Code blocks not working correctly (using Markdown)
- [ ] Probably more errors

Also, this was done pretty quickly, so it doesn't take into account backward compatibility. Keep that in mind.

If anyone wants to improve upon this, feel free to send pull requests to my branch.
