### PR TITLE
Link aliased methods to the original method.

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -174,6 +174,12 @@
               end.join ", " %>
             </div>
           <% end %>
+
+          <% if method.is_alias_for then %>
+            <div class="aka">
+              Alias for: <a href="<%= context.aref_to method.is_alias_for.path %>"><%= h method.is_alias_for.name %></a>
+            </div>
+          <% end %>
           
           <% if method.token_stream %>
             <% markup = method.sdoc_markup_code %>

--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -174,6 +174,12 @@
               end.join ", " %>
             </div>
           <% end %>
+
+          <% if method.is_alias_for then %>
+            <div class="aka">
+              Alias for: <a href="<%= context.aref_to method.is_alias_for.path %>"><%= h method.is_alias_for.name %></a>
+            </div>
+          <% end %>
           
           <% if method.token_stream %>
             <% markup = method.sdoc_markup_code %>


### PR DESCRIPTION
This commit adds "Alias for: original_method" to the documentation of an aliased method, making it much easier to find the original method.
