### PR TITLE
Unordered lists inside ordered ones render ordered

### DIFF
--- a/lib/rdoc/generator/template/sdoc/resources/css/main.css
+++ b/lib/rdoc/generator/template/sdoc/resources/css/main.css
@@ -90,16 +90,6 @@ li
     margin: 0 0 0.5em 2em;
 }
 
-ul li
-{
-    list-style: disc;
-}
-
-ol li
-{
-    list-style: decimal;
-}
-
 .banner
 {
     background: #EDF3FE;


### PR DESCRIPTION
CSS `ol li { list-type: decimal }` makes unordered lists inside ordered ones display as ordered: http://cssdesk.com/cAGg5

Since `ul li { list-type: disc }` and `ol li { list-type: decimal }` are the browser defaults, I believe we don't need these rules
