### PR TITLE
Remove redundany < 5.0 from rdoc dependency specification

### DIFF
--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.add_runtime_dependency('rdoc', "~> 4.0", "< 5.0")
+  s.add_runtime_dependency("rdoc", "~> 4.0")
 
   if defined?(JRUBY_VERSION)
     s.platform = Gem::Platform.new(['universal', 'java', nil])


### PR DESCRIPTION
Using the [pessimistic version constraint](http://guides.rubygems.org/patterns/) in this case (`~> 4.0`) implies `< 5`, so specifying `< 5` is redundant. This explains why the previous specification `~> 3.10` was not satisfied by any `rdoc` 4 versions.
