### PR TITLE
Remove code tags styling under pre elements

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/github.css
+++ b/lib/rdoc/generator/template/rails/resources/css/github.css
@@ -4,12 +4,6 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
 
-pre code {
-  display: block; padding: 0.5em;
-  color: #000;
-  background: #f8f8ff
-}
-
 pre .comment,
 pre .template_comment,
 pre .diff .header,


### PR DESCRIPTION
Hello,

this is just a tiny pull request that fixes code blocks' style. Since RDoc 4+ now wraps code blocks under a `code` tag, the style of the code blocks is not backward compatible with the previous one.

Fixes #67.

Have a nice day.
