### PR TITLE
Move version to separate file, remove require_relative from gemspec

### DIFF
--- a/lib/sdoc.rb
+++ b/lib/sdoc.rb
@@ -2,8 +2,4 @@ $:.unshift File.dirname(__FILE__)
 require "rubygems"
 gem 'rdoc'
 
-module SDoc
-  VERSION = "0.4.0"
-end
-
 require 'sdoc/generator'

--- a/lib/sdoc/version.rb
+++ b/lib/sdoc/version.rb
@@ -1,0 +1,3 @@
+module SDoc
+  VERSION = '0.4.0'
+end

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -1,5 +1,9 @@
 # -*- encoding: utf-8 -*-
-require_relative 'lib/sdoc.rb'
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'sdoc/version'
 
 Gem::Specification.new do |s|
   s.name = "sdoc"


### PR DESCRIPTION
I got the following error:

```
$ bundle update sdoc
Fetching git://github.com/voloko/sdoc.git
There was a LoadError while loading sdoc.gemspec: 
cannot infer basepath from
  /Users/manuel/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/sdoc-1a0e80c2d629/sdoc.gemspec:2:in `require_relative'

Does it try to require a relative path? That's been removed in Ruby 1.9.
```

So I removed the `require_relative` from the gemspec and in the same process moved the version constant into a separate file so only that that needs to be loaded.
