### PR TITLE
Initialize SDoc namespace in main file

### DIFF
--- a/lib/sdoc.rb
+++ b/lib/sdoc.rb
@@ -2,4 +2,7 @@ $:.unshift File.dirname(__FILE__)
 require "rubygems"
 gem 'rdoc'
 
+module SDoc
+end
+
 require 'sdoc/generator'


### PR DESCRIPTION
In #73 I removed the `module SDoc` from `lib/sdoc.rb` which makes SDoc blow up on loading... :crying_cat_face: 
