### PR TITLE
Add <br> between multiple call-seq on a method

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -150,7 +150,7 @@
         <div class="method">
           <div class="title method-title" id="<%= method.aref %>">
             <% if method.call_seq %>
-              <b><%= method.call_seq.gsub(/->/, '&rarr;') %></b>
+              <b><%= method.call_seq.gsub(/->/, '&rarr;').gsub(/\n(.)/, '<br />\1') %></b>
             <% else %>
               <b><%= h method.name %></b><%= h method.params %>
             <% end %>

--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -150,7 +150,7 @@
         <div class="method">
           <div class="title method-title" id="<%= method.aref %>">
             <% if method.call_seq %>
-              <b><%= method.call_seq.gsub(/->/, '&rarr;') %></b>
+              <b><%= method.call_seq.gsub(/->/, '&rarr;').gsub(/\n(.)/, '<br />\1') %></b>
             <% else %>
               <b><%= h method.name %></b><%= h method.params %>
             <% end %>


### PR DESCRIPTION
RDoc accepts the :call-seq: options to specify how to override the
parameters of a method.

According to [its documentation](http://ruby-doc.org/stdlib-2.0.0/libdoc/rdoc/rdoc/RDoc/Markup.html#class-RDoc::Markup-label-Method+arguments) multiple lines may be used; for instance the following is a valid way to
document the fact that `button_to` accepts its caption as either the 'name' parameter or as a block:

``` ruby
# :call-seq:
#   button_to(name = nil, options = nil, html_options = nil)
#   button_to(options = nil, html_options = nil, &block)
```

Running `sdoc` with the code above, however, prints the two declarations
of the method on the same line:

![with-br](https://cloud.githubusercontent.com/assets/10076/4379400/5bd8ec1e-4360-11e4-906e-42d9f86d293b.png)

This PR ensures that a `<br>` is added between lines if multiple values for `call-seq` are provided. The result looks like this:

![without-br](https://cloud.githubusercontent.com/assets/10076/4379401/5bda4370-4360-11e4-9368-a1b8645ada03.png)

Note that the regex in the code ensures that _the last `\n` in the code_ is not replaced by a `<br>`, only the internal ones, so there is no extra space between the name of the method and the dotted border line below it.
