### PR TITLE
Format constants similar to methods

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -102,21 +102,39 @@
     <% unless constants.empty? %>
       <!-- Section constants -->
       <h2 class="sectiontitle">Constants</h2>
-      <table border='0' cellpadding='5'>
         <% constants.each do |const| %>
-          <tr valign='top'>
-            <td class="attr-name"><%= h const.name %></td>
-            <td>=</td>
-            <td class="attr-value"><%= h const.value %></td>
-          </tr>
-          <% if const.comment %>
-            <tr valign='top'>
-              <td>&nbsp;</td>
-              <td colspan="2" class="attr-desc"><%= const.description.strip %></td>
-            </tr>
-          <% end %>
+          <div class="constant">
+            <h3 class="title constant-title">
+              <%= h const.name %>
+            </h3>
+            <% if const.comment && !const.is_alias_for %>
+              <div class="description">
+                <%= const.description.strip %></td>
+              </div>
+            <% end %>
+            <% markup = const.value %>
+            <div class="sourcecode">
+              <%
+                # generate github link
+                github = if options.github
+                  github_link(markup)
+                else
+                  false
+                end
+
+                ghost = false
+                source_id = "#{h const.name}_source"
+              %>
+              <p class="source-link">
+                <% if !ghost || github %> Value: <% end %>
+                <%= source_link(source_id, github, ghost) %>
+              </p>
+              <div id="<%= source_id %>" class="dyn-source">
+                <pre><%= markup %></pre>
+              </div>
+            </div>
+          </div>
         <% end %>
-      </table>
     <% end %>
 
 
@@ -187,31 +205,19 @@
               <%
                 # generate github link
                 github = if options.github
-                  if markup =~ /File\s(\S+), line (\d+)/
-                    path = $1
-                    line = $2.to_i
-                  end
-                  path && github_url(path)
+                  github_link(markup)
                 else
                   false
                 end
 
                 ghost = method.instance_of?(RDoc::GhostMethod)
+                source_id = "#{method.aref}_source"
               %>
               <p class="source-link">
                 <% if !ghost || github %> Source: <% end %>
-
-                <% unless ghost %>
-                  <a href="javascript:toggleSource('<%= method.aref %>_source')" id="l_<%= method.aref %>_source">show</a>
-                <% end %>
-
-                <% if !ghost && github %> | <% end %>
-
-                <% if github %>
-                  <a href="<%= "#{github}#L#{line}" %>" target="_blank" class="github_url">on GitHub</a>
-                <% end %>
+                <%= source_link(source_id, github, ghost) %>
               </p>
-              <div id="<%= method.aref %>_source" class="dyn-source">
+              <div id="<%= source_id %>" class="dyn-source">
                 <pre><%= markup %></pre>
               </div>
             </div>

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -293,9 +293,18 @@ tt {
 .description pre {
   padding: 1em 1.2em;
   background: #EEEEEE;
-  border-radius: 10px;
-  font-size: 15px;
+  border-radius: 10px 15px;
   overflow-x: scroll;
+}
+
+.constant .constant-title {
+  border-bottom: 1px dotted #666;
+}
+
+.constant .description,
+.constant .sourcecode
+{
+  margin-left: 1.2em;
 }
 
 .method {
@@ -315,6 +324,7 @@ tt {
     font-size: 1.1em;
     color:#333;
 }
+
 .method .method-title {
     border-bottom: 1px dotted #666;
     padding: 0 0 0.15em 0;

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -45,6 +45,29 @@ module SDoc::Helpers
     return "#{canonical_url}/#{context.as_href("")}"
   end
 
+  def github_link(markup)
+    if markup =~ /File\s(\S+), line (\d+)/
+      path = $1
+      line = $2.to_i
+    end
+    path && github_url(path)
+  end
+
+  def source_link(source_id, github, ghost)
+    link = ""
+
+    unless ghost
+      link << "<a href=\"javascript:toggleSource('#{source_id}')\" id=\"l_#{source_id}\">show</a>"
+    end
+
+    link << " | " if !ghost && github
+
+    if github
+      github_link_url = "#{github}#L#{line}"
+      link << "<a href=\"#{github_link_url}\" target=\"_blank\" class=\"github_url\">on GitHub</a>"
+    end
+    link
+  end
 protected
   def group_name name
     if match = name.match(/^([a-z])/i)


### PR DESCRIPTION
To improve formatting of constants we can copy the formatting from methods.
Values are hidden but can be toggled to show the value similar to methods.
As aliased constants can have documentation that can break the layout, we don't render these.

<img width="720" alt="image" src="https://user-images.githubusercontent.com/28561/233470608-fe4fc07f-3ebe-48f7-97a1-7bf60bad23e8.png">
