### PR TITLE
Use smaller margins on mobile

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -34,9 +34,7 @@ footer {
 }
 
 #footerContent {
-  margin: 2em;
-  margin-left: 3.5em;
-  margin-right: 3.5em;
+  margin: 2em 3.5em;
   max-width: 980px;
 }
 
@@ -210,10 +208,14 @@ pre
 }
 
 #content {
-  margin: 2em;
-  margin-left: 3.5em;
-  margin-right: 3.5em;
-  max-width: 980px;
+  margin: 1em;
+}
+
+@media (min-width: 40em) {
+  #content {
+    max-width: 980px;
+    margin: 2em 3.5em;
+  }
 }
 
 .sectiontitle {


### PR DESCRIPTION
This allows for more content to fit.

### Before
<img width="409" alt="image" src="https://user-images.githubusercontent.com/28561/233587489-6d4da792-9ce4-4a7c-8eb5-38dd024d5434.png">

### After
<img width="411" alt="image" src="https://user-images.githubusercontent.com/28561/233587623-3c91a291-a605-4b34-83f5-76f739226ea7.png">
