### PR TITLE
Add scroll padding for anchor links on mobile

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -5,6 +5,10 @@
     }
 
     @media (max-width: 599px) {
+        html {
+            scroll-padding-top: 50px;
+        }
+
         .panel_mobile_button {
             display: block;
             height: 40px;


### PR DESCRIPTION
As the menu bar is fixed on mobile and overlaps the content we need to add scroll padding for the anchor links to be visible.

Source: https://stackoverflow.com/a/56467997