### PR TITLE
Set grid width to fix overflowing content

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -11,6 +11,7 @@ body {
   min-height: 100%;
   display: grid;
   grid-template-rows: min-content min-content auto min-content;
+  grid-template-columns: 100%;
 }
 
 nav {


### PR DESCRIPTION
When the `grid-template-columns` isn't set, the grid can be any width making `#bodyContent` wider than the screen width instead of adding scrollbars for the code examples.

### Before

<img width="397" alt="image" src="https://user-images.githubusercontent.com/28561/233614061-b6b66f18-c908-41dd-9a1e-10d5aef122af.png">

### After

<img width="434" alt="image" src="https://user-images.githubusercontent.com/28561/233614591-35d85c66-cb78-4e9a-a344-d27631f47b70.png">
