### PR TITLE
Move Namespace section to the bottom and rename to Classes and Modules

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -28,23 +28,6 @@
     </ul>
   <% end %>
 
-
-  <% unless context.classes_and_modules.empty? %>
-    <!-- Namespace -->
-    <details>
-      <summary class="sectiontitle">Namespace</summary>
-      <ul>
-        <% (context.modules.sort + context.classes.sort).each do |mod| %>
-          <li>
-            <span class="type"><%= mod.type.upcase %></span>
-            <a href="<%= context.aref_to mod.path %>"><%= mod.full_name %></a>
-          </li>
-        <% end %>
-      </ul>
-    </details>
-  <% end %>
-
-
   <% unless context.method_list.empty? %>
     <!-- Method ref -->
     <div class="sectiontitle">Methods</div>
@@ -138,7 +121,6 @@
       </table>
     <% end %>
 
-
     <!-- Methods -->
     <%
       context.methods_by_type(section).each do |type, visibilities|
@@ -223,4 +205,17 @@
       <% end %><%# visibilities.each %>
     <% end %><%# context.methods_by_type %>
   <% end %><%# context.each_section %>
+
+  <% unless context.classes_and_modules.empty? %>
+    <!-- Namespace -->
+    <div class="sectiontitle">Namespace</div>
+    <ul>
+      <% (context.modules.sort + context.classes.sort).each do |mod| %>
+        <li>
+          <span class="type"><%= mod.type.upcase %></span>
+          <a href="<%= context.aref_to mod.path %>"><%= mod.full_name %></a>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
 </div>


### PR DESCRIPTION
Alternative implementation to "Make namespace section expandable" 809e71444dbf47af1ebaddf9df0cb39cb304a53a.

Pages that only show namespaces would benefit from having the namespaces expanded. To prevent the namespaces from taking up valuable page real estate we can move the namespaces to the bottom.

This also renames "Namespace" to "Classes and Modules" to better describe the contents of the section.