### PR TITLE
Make path to logo relative

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -3,7 +3,7 @@
 <nav class="panel panel_tree" id="panel" data-turbo-permanent>
   <div class="logo">
     <a href="/">
-      <img width="300" src="/i/logo.svg" alt="Ruby on Rails logo">
+      <img width="300" src="<%= rel_prefix %>/i/logo.svg" alt="Ruby on Rails logo">
     </a>
   </div>
   <div class="header">

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -21,7 +21,7 @@
     <a class="sr-only sr-only-focusable" href="#content" data-turbo="false">Skip to Content</a>
     <a class="sr-only sr-only-focusable" href="#search" data-turbo="false">Skip to Search</a>
 
-    <%= include_template '_panel.rhtml' %>
+    <%= include_template '_panel.rhtml', {:rel_prefix => rel_prefix} %>
 
     <div class="banner">
         <% if ENV['HORO_PROJECT_NAME'] %>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -11,7 +11,7 @@
     <a class="sr-only sr-only-focusable" href="#content" data-turbo="false">Skip to Content</a>
     <a class="sr-only sr-only-focusable" href="#search" data-turbo="false">Skip to Search</a>
 
-    <%= include_template '_panel.rhtml' %>
+    <%= include_template '_panel.rhtml', {:rel_prefix => rel_prefix} %>
 
     <div class="banner">
         <% if ENV['HORO_PROJECT_NAME'] %>

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -11,7 +11,7 @@
     <a class="sr-only sr-only-focusable" href="#content" data-turbo="false">Skip to Content</a>
     <a class="sr-only sr-only-focusable" href="#search" data-turbo="false">Skip to Search</a>
 
-    <%= include_template '_panel.rhtml' %>
+    <%= include_template '_panel.rhtml', {:rel_prefix => rel_prefix} %>
 
     <div class="banner">
         <% if ENV['HORO_PROJECT_NAME'] %>


### PR DESCRIPTION
This makes sure the logo works when generating the docs locally. It also makes sure the logo still works for older rails versions where the version is in the URL, like: https://api.rubyonrails.org/v6.1/