### PR TITLE
Fix `config.ru` for Ruby 3.2

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -6,7 +6,7 @@
 require 'bundler/setup'
 
 root = "doc/public"
-unless Dir.exists?(root)
+unless Dir.exist?(root)
   puts <<~MESSAGE
     Could not find any docs in #{root}.
     Run the following command to generate sample documentation:


### PR DESCRIPTION
Ruby 3.2 removed `Dir.exists?` in favor of `Dir.exist?`.