### PR TITLE
Fix circular loading warning

### DIFF
--- a/lib/rdoc/discover.rb
+++ b/lib/rdoc/discover.rb
@@ -1,5 +1,5 @@
 begin
   gem 'rdoc', '>= 5.0'
-  require File.join(File.dirname(__FILE__), '/../sdoc')
+  require_relative "../sdoc" unless defined?(SDoc)
 rescue Gem::LoadError
 end


### PR DESCRIPTION
This fixes the following warning when running `rake test`:

  ```
  sdoc/lib/rdoc/discover.rb:4: warning: sdoc/lib/rdoc/discover.rb:4: warning: loading in progress, circular require considered harmful - sdoc/lib/sdoc.rb
    from ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in  `<main>'
    from ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in  `select'
    from ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in  `block in <main>'
    from <internal:ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
    from <internal:ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
    from sdoc/spec/helpers_spec.rb:1:in  `<top (required)>'
    from <internal:ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
    from <internal:ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in  `require'
    from sdoc/spec/spec_helper.rb:3:in  `<top (required)>'
    from sdoc/spec/spec_helper.rb:3:in  `require'
    from sdoc/lib/sdoc.rb:5:in  `<top (required)>'
    from sdoc/lib/sdoc.rb:5:in  `require'
    from sdoc/lib/sdoc/generator.rb:23:in  `<top (required)>'
    from sdoc/lib/sdoc/generator.rb:24:in  `<class:SDoc>'
    from sdoc/lib/sdoc/generator.rb:24:in  `require'
    from ruby/3.2.0/rdoc/rdoc.rb:551:in  `<top (required)>'
    from ruby/3.2.0/rdoc/rdoc.rb:551:in  `each'
    from ruby/3.2.0/rdoc/rdoc.rb:553:in  `block in <top (required)>'
    from ruby/3.2.0/rdoc/rdoc.rb:553:in  `load'
    from sdoc/lib/rdoc/discover.rb:4:in  `<top (required)>'
    from sdoc/lib/rdoc/discover.rb:4:in  `require'
  ```