### PR TITLE
Require Ruby >= 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,6 @@ gem "rake"
 gem "hoe"
 gem "minitest"
 
-if RUBY_VERSION.to_f <= 2.5
-  gem "psych", "< 4.0"
-end
-
 if ENV["rdoc"] == "master"
   gem "rdoc", :github => "ruby/rdoc"
 end

--- a/lib/sdoc/templatable.rb
+++ b/lib/sdoc/templatable.rb
@@ -6,11 +6,7 @@ module SDoc::Templatable
   ### Both +templatefile+ and +outfile+ should be Pathname-like objects.
   def eval_template(templatefile, context)
     template_src = templatefile.read
-    template = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
-      ERB.new( template_src, trim_mode: '<>' )
-    else
-      ERB.new( template_src, nil, '<>' )
-    end
+    template = ERB.new(template_src, trim_mode: "<>")
     template.filename = templatefile.to_s
 
     begin

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -15,9 +15,7 @@ Gem::Specification.new do |s|
 
   s.require_path = 'lib'
 
-  s.required_ruby_version = Gem::Requirement.new('>= 1.9.3')
-  s.required_rubygems_version = Gem::Requirement.new(">= 1.3.6") if
-    s.respond_to? :required_rubygems_version=
+  s.required_ruby_version = ">= 2.7"
 
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]


### PR DESCRIPTION
This matches `.github/workflows/test.yml` which only tests Ruby >= 2.7.