### PR TITLE
Mark vendored JavaScript assets as binary in git

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/.gitattributes
+++ b/lib/rdoc/generator/template/rails/resources/js/.gitattributes
@@ -1,0 +1,3 @@
+@hotwired--turbo.js binary
+highlight.pack.js binary
+jquery-*.min.js binary


### PR DESCRIPTION
The `binary` attribute suppresses each file's contents from the output of `git grep` and `git diff`.  It also excludes each file from the project's language stats on GitHub.