### PR TITLE
Put `<meta charset>` tag first

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="<%= @options.charset %>">
     <title><%= h klass.full_name %></title>
-    <meta charset="<%= @options.charset %>" />
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:context => klass, :rel_prefix => rel_prefix, :tree_keys => klass.full_name.split('::') } %>
 

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="<%= @options.charset %>">
     <title><%= h file.name %></title>
-    <meta charset="<%= @options.charset %>" />
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:context => file, :rel_prefix => rel_prefix, :tree_keys => [] } %>
 </head>

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="<%= @options.charset %>">
     <title><%= @options.title %></title>
-    <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:context => :index, :rel_prefix => rel_prefix, tree_keys: []} %>
 </head>

--- a/lib/rdoc/generator/template/rails/search_index.rhtml
+++ b/lib/rdoc/generator/template/rails/search_index.rhtml
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="<%= @options.charset %>">
     <title>File Index</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>


### PR DESCRIPTION
The `<meta charset>` tag should appear before any elements that contain text, including the `<title>` element.