### PR TITLE
Hide scrollbar for unscrollable code snippets

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -313,7 +313,7 @@ tt {
   background: #EEEEEE;
   border-radius: 10px;
   font-size: 15px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .method {


### PR DESCRIPTION
`overflow-x: scroll` always shows a scrollbar, whereas `overflow-x: auto` shows a scrollbar only when necessary.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/7d3d479c-0454-46bf-9052-75535e8be916) | ![after](https://github.com/rails/sdoc/assets/771968/aee894b9-e5b0-4c9a-a4a8-e4ef68d1fd61) |
