### PR TITLE
Remove obsolete HTML escaping hack

### DIFF
--- a/lib/sdoc/templatable.rb
+++ b/lib/sdoc/templatable.rb
@@ -34,17 +34,6 @@ module SDoc::Templatable
   def render_template( templatefile, context, outfile )
     output = eval_template(templatefile, context)
 
-    # TODO delete this dirty hack when documentation for example for GeneratorMethods will not be cutted off by <script> tag
-    begin
-      if output.respond_to? :force_encoding
-        encoding = output.encoding
-        output = output.force_encoding('ASCII-8BIT').gsub('<script>', '&lt;script;&gt;').force_encoding(encoding)
-      else
-        output = output.gsub('<script>', '&lt;script&gt;')
-      end
-    rescue Exception
-    end
-
     unless $dryrun
       outfile.dirname.mkpath
       outfile.open( 'w', 0644 ) do |file|


### PR DESCRIPTION
This hack dates back to 337c94b5761910ed0f51a435fd78a9abf4559467, made in 2009, which corresponds to RDoc v2.4.3.

Since then, the original problem appears to be fixed in RDoc, as can be observed for the `ActionView::Helpers::JavaScriptHelper#javascript_tag` doc in Rails v7.0.6.