### PR TITLE
Replace `rel_prefix` with `<base>` tag + postprocessing

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -139,7 +139,7 @@
               <b><%= h method.name %></b><%= h method.params %>
             <% end %>
           </h3>
-          <a href="<%= "#{rel_prefix}/#{context.path}##{method.aref}"%>" name="<%= method.aref %>" class="permalink">Link</a>
+          <a href="<%= "/#{context.path}##{method.aref}"%>" name="<%= method.aref %>" class="permalink">Link</a>
 
           <% if method.comment %>
             <div class="description">

--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -1,15 +1,15 @@
-<link rel="stylesheet" href="<%= rel_prefix %>/css/reset.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="<%= rel_prefix %>/css/panel.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="<%= rel_prefix %>/css/main.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="<%= rel_prefix %>/css/highlight.css" type="text/css" media="screen" />
-<script src="<%= rel_prefix %>/js/jquery-3.5.1.min.js" type="text/javascript" charset="utf-8"></script>
-<script src="<%= rel_prefix %>/js/main.js" type="text/javascript" charset="utf-8"></script>
-<script src="<%= rel_prefix %>/js/@hotwired--turbo.js" type="text/javascript" charset="utf-8"></script>
-<script src="<%= rel_prefix %>/js/search_index.js" type="text/javascript" charset="utf-8"></script>
-<script src="<%= rel_prefix %>/js/searcher.js" type="text/javascript" charset="utf-8"></script>
-<script src="<%= rel_prefix %>/panel/tree.js" type="text/javascript" charset="utf-8"></script>
-<script src="<%= rel_prefix %>/js/searchdoc.js" type="text/javascript" charset="utf-8"></script>
-<meta name="data-rel-prefix" content="<%= rel_prefix %>/">
+<%= base_tag_for_context(context) %>
+<link rel="stylesheet" href="/css/reset.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="/css/panel.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="/css/main.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="/css/highlight.css" type="text/css" media="screen" />
+<script src="/js/jquery-3.5.1.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="/js/main.js" type="text/javascript" charset="utf-8"></script>
+<script src="/js/@hotwired--turbo.js" type="text/javascript" charset="utf-8"></script>
+<script src="/js/search_index.js" type="text/javascript" charset="utf-8"></script>
+<script src="/js/searcher.js" type="text/javascript" charset="utf-8"></script>
+<script src="/panel/tree.js" type="text/javascript" charset="utf-8"></script>
+<script src="/js/searchdoc.js" type="text/javascript" charset="utf-8"></script>
 <meta name="data-tree-keys" content='<%= tree_keys %>'>
 <% if ENV['HORO_CANONICAL_URL'] %>
 <link rel="canonical" href="<%= horo_canonical_url(ENV['HORO_CANONICAL_URL'], context) %>" />

--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -4,7 +4,7 @@
 <nav class="panel panel_tree" id="panel" data-turbo-permanent>
   <div class="logo">
     <a href="/">
-      <img width="300" src="<%= rel_prefix %>/i/logo.svg" alt="Ruby on Rails logo">
+      <img width="300" src="/i/logo.svg" alt="Ruby on Rails logo">
     </a>
   </div>
   <div class="header">

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -4,7 +4,7 @@
     <meta charset="<%= @options.charset %>">
     <title><%= h klass.full_name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= include_template '_head.rhtml', {:context => klass, :rel_prefix => rel_prefix, :tree_keys => klass.full_name.split('::') } %>
+    <%= include_template '_head.rhtml', {:context => klass, :tree_keys => klass.full_name.split('::') } %>
 
     <meta property="og:title" value="<%= klass.full_name %>">
 
@@ -21,7 +21,7 @@
     <a class="sr-only sr-only-focusable" href="#content" data-turbo="false">Skip to Content</a>
     <a class="sr-only sr-only-focusable" href="#search" data-turbo="false">Skip to Search</a>
 
-    <%= include_template '_panel.rhtml', {:rel_prefix => rel_prefix} %>
+    <%= include_template '_panel.rhtml' %>
 
     <div class="banner">
         <% if ENV['HORO_PROJECT_NAME'] %>
@@ -46,7 +46,7 @@
     </div>
 
     <main id="bodyContent">
-        <%= include_template '_context.rhtml', {:context => klass, :rel_prefix => rel_prefix} %>
+        <%= include_template '_context.rhtml', {:context => klass} %>
     </main>
 
     <footer>
@@ -55,7 +55,7 @@
                 <summary class="sectiontitle">Appears in</summary>
                 <ul class="files">
                     <% klass.in_files.each do |file| %>
-                    <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
+                    <li><a href="/<%= h file.path %>"><%= h file.absolute_name %></a></li>
                     <% end  %>
                 </ul>
             </details>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -4,14 +4,14 @@
     <meta charset="<%= @options.charset %>">
     <title><%= h file.name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= include_template '_head.rhtml', {:context => file, :rel_prefix => rel_prefix, :tree_keys => [] } %>
+    <%= include_template '_head.rhtml', {:context => file, :tree_keys => [] } %>
 </head>
 
 <body>
     <a class="sr-only sr-only-focusable" href="#content" data-turbo="false">Skip to Content</a>
     <a class="sr-only sr-only-focusable" href="#search" data-turbo="false">Skip to Search</a>
 
-    <%= include_template '_panel.rhtml', {:rel_prefix => rel_prefix} %>
+    <%= include_template '_panel.rhtml' %>
 
     <div class="banner">
         <% if ENV['HORO_PROJECT_NAME'] %>
@@ -38,7 +38,7 @@
     </div>
 
     <main id="bodyContent">
-        <%= include_template '_context.rhtml', {:context => file, :rel_prefix => rel_prefix} %>
+        <%= include_template '_context.rhtml', {:context => file} %>
     </main>
   </body>
 </html>

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -4,14 +4,14 @@
     <meta charset="<%= @options.charset %>">
     <title><%= @options.title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= include_template '_head.rhtml', {:context => :index, :rel_prefix => rel_prefix, tree_keys: []} %>
+    <%= include_template '_head.rhtml', {:context => :index, tree_keys: []} %>
 </head>
 
 <body>
     <a class="sr-only sr-only-focusable" href="#content" data-turbo="false">Skip to Content</a>
     <a class="sr-only sr-only-focusable" href="#search" data-turbo="false">Skip to Search</a>
 
-    <%= include_template '_panel.rhtml', {:rel_prefix => rel_prefix} %>
+    <%= include_template '_panel.rhtml' %>
 
     <div class="banner">
         <% if ENV['HORO_PROJECT_NAME'] %>

--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -230,7 +230,7 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
     };
 
     this.open = function(src) {
-        var location = $('meta[name="data-rel-prefix"]').attr("content") + src;
+        var location = $("base").attr("href") + src;
         Turbo.visit(location);
         if (this.highlight) this.highlight(src);
     };

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -116,7 +116,6 @@ class RDoc::Generator::SDoc
     debug_msg "Generating index file in #{@outputdir}"
     templatefile = @template_dir + 'index.rhtml'
     outfile      = @outputdir + 'index.html'
-    rel_prefix = rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
     self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
   end
@@ -129,7 +128,6 @@ class RDoc::Generator::SDoc
     @classes.each do |klass|
       debug_msg "  working on %s (%s)" % [ klass.full_name, klass.path ]
       outfile     = @outputdir + klass.path
-      rel_prefix = rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
       debug_msg "  rendering #{outfile}"
       self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
@@ -144,7 +142,6 @@ class RDoc::Generator::SDoc
     @files.each do |file|
       outfile     = @outputdir + file.path
       debug_msg "  working on %s (%s)" % [ file.full_name, outfile ]
-      rel_prefix = rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
       debug_msg "  rendering #{outfile}"
       self.render_template( templatefile, binding(), outfile ) unless @options.dry_run

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -37,6 +37,15 @@ module SDoc::Helpers
     end
   end
 
+  def base_tag_for_context(context)
+    if context == :index
+      %(<base href="./" data-current-path=".">)
+    else
+      relative_root = "../" * context.path.count("/")
+      %(<base href="#{relative_root}" data-current-path="#{context.path}">)
+    end
+  end
+
   def horo_canonical_url(canonical_url, context)
     if context == :index
       return "#{canonical_url}/"

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -29,4 +29,26 @@ describe SDoc::Helpers do
       _(@helpers.truncate("Hello world", length: 5)).must_equal "Hello."
     end
   end
+
+  describe "#base_tag_for_context" do
+    it "returns an idempotent <base> tag for the :index context" do
+      _(@helpers.base_tag_for_context(:index)).
+        must_equal %(<base href="./" data-current-path=".">)
+    end
+
+    it "returns a <base> tag with an appropriate path for the given RDoc::Context" do
+      top_level = rdoc_top_level_for <<~RUBY
+        module Foo; module Bar; module Qux; end; end; end
+      RUBY
+
+      _(@helpers.base_tag_for_context(top_level.find_module_named("Foo"))).
+        must_equal %(<base href="../" data-current-path="classes/Foo.html">)
+
+      _(@helpers.base_tag_for_context(top_level.find_module_named("Foo::Bar"))).
+        must_equal %(<base href="../../" data-current-path="classes/Foo/Bar.html">)
+
+      _(@helpers.base_tag_for_context(top_level.find_module_named("Foo::Bar::Qux"))).
+        must_equal %(<base href="../../../" data-current-path="classes/Foo/Bar/Qux.html">)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,20 @@ require 'bundler/setup'
 require 'sdoc'
 
 require 'minitest/autorun'
+
+# Returns an RDoc::TopLevel instance for the given Ruby code.
+def rdoc_top_level_for(ruby_code)
+  # RDoc has a lot of internal state that needs to be initialized. The most
+  # foolproof way to initialize it is by simply running it with a dummy file.
+  $rdoc_for_specs ||= RDoc::RDoc.new.tap do |rdoc|
+    rdoc.document(%W[--dry-run --quiet --format=sdoc --template=rails --files #{__FILE__}])
+  end
+
+  $rdoc_for_specs.store = RDoc::Store.new
+
+  Dir.mktmpdir do |dir|
+    path = "#{dir}/ruby_code.rb"
+    File.write(path, ruby_code)
+    $rdoc_for_specs.parse_file(path)
+  end
+end


### PR DESCRIPTION
The Rails logo in the `data-turbo-permanent` part of the navigation panel uses a path that is static after the first page load.  #228 made the path relative, but it is still static.  This means that, when navigating to a different page, the relative path is re-resolved using that page's URL.

For example, when first visiting `foo/bar.html`, the image URL will be `../i/logo.svg` which resolves to `/i/logo.svg`.  Then, after clicking a link to `foo/bar/qux.html`, the image URL will still be `../i/logo.svg` but will resolve to `foo/i/logo.svg`, causing the image to break.

More generally, any relative URLs in a `data-turbo-permanent` element will break when navigating to a different directory level.  This hinders us from adding static `<a>` elements to the navigation panel as well. (The current navigation tree sidesteps this problem by using JavaScript click handlers instead of actual links, but that has its own issues.)

As a solution, this commit replaces the use of `rel_prefix` with a [`<base>`][] tag and coordinated postprocessing of URLs.

The `<base>` tag for each page uses the (former) `rel_prefix` for that page.  For example, the `<base>` tag for `foo/bar.html` would be `<base href="../">`, and for `foo/bar/qux.html` would be `<base href="../../">`.

Postprocessing then converts all URLs on each page so that they can be resolved relative to the `<base>` tag.

URLs that previously used `rel_prefix` are now written as absolute paths.  Postprocessing converts them to relative paths.  For example, `#{rel_prefix}/i/logo.svg` is now written as just `/i/logo.svg`, which postprocessing converts to `i/logo.svg`, which is resolved as `../i/logo.svg` in `foo/bar.html` or `../../i/logo.svg` in `foo/bar/qux.html`.

This fixes the disappearing logo, and allows us to put links and images inside the `data-turbo-permanent` part of the navigation panel without additional JavaScript.

This also addresses the issue that #176 describes, wherein Turbo will reload assets when they have a different relative URL, even if they would resolve to the same absolute URL.  Because asset paths are now the same for all pages, Turbo will no longer reload them.

[`<base>`]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
