### PR TITLE
Demo the issue solved by #240

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -7,6 +7,7 @@
       <img width="300" src="<%= rel_prefix %>/i/logo.svg" alt="Ruby on Rails logo">
     </a>
   </div>
+  <div><a href="<%= rel_prefix %>/classes/ActiveRecord/Base.html">CLICK ME!</a></div>
   <div class="header">
     <input type="text" placeholder="Search (/) for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" tabindex="-1" />
     <label class="panel_mobile_button_close" for="hamburger"><span></span> Close</label>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,17 +3,7 @@
   publish = "doc/public"
 
 [build.processing]
-  skip_processing = false
-[build.processing.css]
-  bundle = true
-  minify = true
-[build.processing.js]
-  bundle = true
-  minify = true
-[build.processing.html]
-  pretty_urls = true
-[build.processing.images]
-  compress = true
+  skip_processing = true
 
 [[headers]]
   for = "*"


### PR DESCRIPTION
This demonstrates the issue that #240 solves.

Netlify converts image URLs to absolute (CDN) URLs, so the disappearing logo problem did not appear in the Netlify doc previews.  I pushed a commit that disables Netlify build processing for this branch, so the problem is now observable.

I've also added a link to the `data-turbo-permanent` part of the navigation panel.  The link uses `rel_prefix` the same way the logo image does.  If you click on the link when you first visit the doc preview, it will work.  But if you visit another page first and then click the link, it will 404.  Similarly, if you click the link twice, the second time will 404.

See #240 for an explanation.