### PR TITLE
Use Rouge to highlight method source code

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -196,7 +196,7 @@
                 <% end %>
               </p>
               <div id="<%= method.aref %>_source" class="dyn-source">
-                <pre><%= markup %></pre>
+                <pre><code class="ruby"><%= markup %></code></pre>
               </div>
             </div>
             <% end %>

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -298,16 +298,6 @@ tt {
   padding: 0.5em;
 }
 
-.dyn-source .cmt {
-  color: #00F;
-  font-style: italic;
-}
-
-.dyn-source .kw {
-  color: #070;
-  font-weight: bold;
-}
-
 .description pre {
   padding: 1em 1.2em;
   background: #EEEEEE;
@@ -364,45 +354,6 @@ tt {
 .method .source-link
 {
     font-size: 0.85em;
-}
-
-.ruby-constant {
-  color: teal;
-}
-.ruby-keyword {
-  color: #000;
-  font-weight: bold
-}
-.ruby-title {
-  color: #900;
-  font-weight: bold;
-}
-.ruby-ivar {
-  color: teal;
-}
-.ruby-operator {
-  color: #000;
-  font-weight: bold
-}
-.ruby-identifier {
-  color: #000;
-}
-.ruby-string,
-.ruby-node {
-  color: #D14;
-}
-.ruby-comment {
-  color: #998;
-  font-style: italic;
-}
-.ruby-regexp {
-  color: #009926;
-}
-.ruby-value {
-  color: #990073;
-}
-.ruby-number {
-  color: #40A070;
 }
 
 @keyframes spotlight {

--- a/lib/sdoc/postprocessor.rb
+++ b/lib/sdoc/postprocessor.rb
@@ -13,11 +13,11 @@ module SDoc::Postprocessor
   end
 
   def highlight_code_blocks!(document)
-    document.css(".description pre > code").each do |element|
+    document.css(".description pre > code, .sourcecode pre > code").each do |element|
       code = element.inner_text
-      language = guess_code_language(code)
+      language = element.classes.include?("ruby") ? "ruby" : guess_code_language(code)
       element.inner_html = highlight_code(code, language)
-      element.append_class("highlight").append_class(language)
+      element.add_class("highlight").add_class(language)
     end
   end
 

--- a/spec/postprocessor_spec.rb
+++ b/spec/postprocessor_spec.rb
@@ -23,6 +23,30 @@ describe SDoc::Postprocessor do
 
       _(SDoc::Postprocessor.process(rendered)).must_include expected
     end
+
+    it "highlights method source code" do
+      rendered = <<~HTML
+        <div class="sourcecode">
+          <pre><code class="ruby"><span class="ruby-comment"># highlighted by RDoc</span></code></pre>
+        </div>
+
+        <div class="sourcecode">
+          <pre><code class="ruby">DELETE FROM 'tricky_ruby'</code></pre>
+        </div>
+      HTML
+
+      expected = <<~HTML
+        <div class="sourcecode">
+          <pre><code class="ruby highlight">#{SDoc::Postprocessor.highlight_code("# highlighted by RDoc", "ruby")}</code></pre>
+        </div>
+
+        <div class="sourcecode">
+          <pre><code class="ruby highlight">#{SDoc::Postprocessor.highlight_code("DELETE FROM 'tricky_ruby'", "ruby")}</code></pre>
+        </div>
+      HTML
+
+      _(SDoc::Postprocessor.process(rendered)).must_include expected
+    end
   end
 
   describe "#highlight_code" do


### PR DESCRIPTION
Prior to this commit, method source code was syntax highlighted by RDoc and had its own CSS styles.

This commit applies Rouge syntax highlighting to method source code for consistency with other Ruby code blocks, allowing us to reuse the Rouge CSS styles.
