### PR TITLE
Enable horizontal scrollbar for method source code

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -303,6 +303,10 @@ tt {
   background: #EEEEEE;
   border-radius: 10px;
   font-size: 15px;
+}
+
+.description pre,
+.sourcecode pre {
   overflow-x: auto;
 }
 


### PR DESCRIPTION
When method source code is shown and contains long lines, it can overflow and cause the entire page to be horizontally scrollable.

To prevent that, this commit sets `overflow-x: auto` for method source code blocks (the same as for other code blocks), so that only the block is horizontally scrollable.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/8337923f-e61b-426f-a639-89eae78c1cad) | ![after](https://github.com/rails/sdoc/assets/771968/ad2155e8-c2be-45b5-b45f-d05432bdf445) |
