### PR TITLE
Disable Netlify post-processing asset optimization

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,19 +2,6 @@
   command = "bundle exec rake test:rails"
   publish = "doc/public"
 
-[build.processing]
-  skip_processing = false
-[build.processing.css]
-  bundle = true
-  minify = true
-[build.processing.js]
-  bundle = true
-  minify = true
-[build.processing.html]
-  pretty_urls = true
-[build.processing.images]
-  compress = true
-
 [[headers]]
   for = "*"
   [headers.values]


### PR DESCRIPTION
Netlify's post-processing asset optimization can mask URL issues (for example, see #241), and there is no real benefit to optimizing temporary doc previews.

Additionally, the asset optimization feature is deprecated, and will be sunset on 2023-10-17.  See the [notice in the Netlify build logs](https://app.netlify.com/sites/sdoc/deploys/64bb05af56d7e6000866307f#L1406):

> DEPRECATION NOTICE: Your site has asset optimization enabled. This
> feature will be at end of service on October 17, 2023.
>
> After that date, your builds will continue to work but we won't minify
> or bundle the CSS and JS, and we won't optimize images.
> To remove this warning, remove the processing settings from the
> netlify.toml file.
>
> For more details, read our forum announcement:
> https://answers.netlify.com/t/please-read-deprecation-of-post-processing-asset-optimization/96657