### PR TITLE
Add `link_to` helper

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -23,7 +23,7 @@
     <div class="sectiontitle">Sections</div>
     <ul>
       <% sections.each do |section| %>
-        <li><a href="#<%= section.aref %>"><%= h section.title %></a></li>
+        <li><%= link_to section.title, "##{section.aref}" %></li>
       <% end %>
     </ul>
   <% end %>
@@ -40,9 +40,7 @@
               <%
                 comma = group[:methods].size == i+1 ? '' : ','
               %>
-              <li>
-                <a href="#<%= method.aref %>"><%= h method.name %></a><%= comma %>
-              </li>
+              <li><%= link_to method.name, method %><%= comma %></li>
             <% end %>
           </ul>
         </dd>
@@ -56,12 +54,10 @@
     <ul>
       <% context.includes.each do |inc| %>
         <li>
-          <% unless String === inc.module %>
-            <a href="<%= context.aref_to inc.module.path %>">
-              <%= h inc.module.full_name %>
-            </a>
-          <% else %>
+          <% if inc.module.is_a?(String) %>
             <%= h inc.name %>
+          <% else %>
+            <%= link_to inc.module.full_name, inc.module %>
           <% end %>
         </li>
       <% end %>
@@ -139,7 +135,7 @@
               <b><%= h method.name %></b><%= h method.params %>
             <% end %>
           </h3>
-          <a href="<%= "/#{context.path}##{method.aref}"%>" name="<%= method.aref %>" class="permalink">Link</a>
+          <%= link_to "Link", method, class: "permalink", name: method.aref %>
 
           <% if method.comment %>
             <div class="description">
@@ -149,19 +145,16 @@
 
           <% unless method.aliases.empty? %>
             <div class="aka">
-              Also aliased as: <%= method.aliases.map do |aka|
-                if aka.parent then # HACK lib/rexml/encodings
-                  %{<a href="#{context.aref_to aka.path}">#{h aka.name}</a>}
-                else
-                  h aka.name
-                end
-              end.join ", " %>
+              Also aliased as:
+              <%# Sometimes a parent cannot be determined. See ruby/rdoc@85ebfe13dc. %>
+              <%= method.aliases.map { |aka| link_to aka.name, (aka if aka.parent) }.join(", ") %>
             </div>
           <% end %>
 
-          <% if method.is_alias_for then %>
+          <% if alias_for = method.is_alias_for then %>
             <div class="aka">
-              Alias for: <a href="<%= context.aref_to method.is_alias_for.path %>"><%= h method.is_alias_for.name %></a>
+              Alias for:
+              <%= link_to alias_for.name, alias_for %>
             </div>
           <% end %>
 
@@ -213,7 +206,7 @@
       <% (context.modules.sort + context.classes.sort).each do |mod| %>
         <li>
           <span class="type"><%= mod.type.upcase %></span>
-          <a href="<%= context.aref_to mod.path %>"><%= mod.full_name %></a>
+          <%= link_to mod.full_name, mod %>
         </li>
       <% end %>
     </ul>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -32,10 +32,10 @@
             <%= h klass.full_name %>
             <% if klass.type == 'class' %>
                 <span class="parent">&lt;
-                    <% if String === klass.superclass %>
+                    <% if klass.superclass.is_a?(String) %>
                     <%= klass.superclass %>
-                    <% elsif !klass.superclass.nil? %>
-                    <a href="<%= klass.aref_to klass.superclass.path %>"><%= h klass.superclass.full_name %></a>
+                    <% elsif klass.superclass %>
+                    <%= link_to klass.superclass.full_name, klass.superclass %>
                     <% end %>
                 </span>
             <% end %>
@@ -55,8 +55,8 @@
                 <summary class="sectiontitle">Appears in</summary>
                 <ul class="files">
                     <% klass.in_files.each do |file| %>
-                    <li><a href="/<%= h file.path %>"><%= h file.absolute_name %></a></li>
-                    <% end  %>
+                    <li><%= link_to file.absolute_name, file %></li>
+                    <% end %>
                 </ul>
             </details>
         </div>

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -37,6 +37,15 @@ module SDoc::Helpers
     end
   end
 
+  def link_to(text, url, html_attributes = {})
+    return h(text) if url.nil?
+
+    url = "/#{url.path}" if url.is_a?(RDoc::CodeObject)
+    attribute_string = html_attributes.map { |name, value| %( #{name}="#{h value}") }.join
+
+    %(<a href="#{h url}"#{attribute_string}>#{h text}</a>)
+  end
+
   def base_tag_for_context(context)
     if context == :index
       %(<base href="./" data-current-path=".">)


### PR DESCRIPTION
This commit adds a `link_to` helper, inspired by Rails' `link_to` helper.

The helper HTML-escapes the link text and HTML attribute values. Additionally, the helper will convert an `RDoc::CodeObject` to a URL by calling its `path` method.  So instead of writing something like:

  ```erb
  <a href="/<%= rdoc_class.path %>"><%= h rdoc_class.full_name %></a>
  ```

We can write:

  ```erb
  <%= link_to rdoc_class.full_name, rdoc_class %>
  ```