### PR TITLE
Add helpers for `ENV["HORO_*"]` values

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -11,6 +11,6 @@
 <script src="/panel/tree.js" type="text/javascript" charset="utf-8"></script>
 <script src="/js/searchdoc.js" type="text/javascript" charset="utf-8"></script>
 <meta name="data-tree-keys" content='<%= tree_keys %>'>
-<% if ENV['HORO_CANONICAL_URL'] %>
-<link rel="canonical" href="<%= horo_canonical_url(ENV['HORO_CANONICAL_URL'], context) %>" />
+<% if canonical = canonical_url(context) %>
+<link rel="canonical" href="<%= canonical %>" />
 <% end %>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -24,9 +24,10 @@
     <%= include_template '_panel.rhtml' %>
 
     <div class="banner">
-        <% if ENV['HORO_PROJECT_NAME'] %>
-            <span><%= ERB::Util.html_escape(ENV['HORO_PROJECT_NAME']) %> <%= ERB::Util.html_escape(ENV['HORO_PROJECT_VERSION']) %></span><br />
+        <% if project_name %>
+            <div><%= project_name %> <%= project_version %></div>
         <% end %>
+
         <h2>
             <span class="type"><%= klass.module? ? 'Module' : 'Class' %></span>
             <%= h klass.full_name %>
@@ -40,8 +41,9 @@
                 </span>
             <% end %>
         </h2>
-        <% if ENV['HORO_BADGE_VERSION'] %>
-            <div id="version-badge"><%= ENV['HORO_BADGE_VERSION'] %></div>
+
+        <% if badge_version %>
+            <div id="version-badge"><%= badge_version %></div>
         <% end %>
     </div>
 

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -14,9 +14,10 @@
     <%= include_template '_panel.rhtml' %>
 
     <div class="banner">
-        <% if ENV['HORO_PROJECT_NAME'] %>
-            <span><%= ERB::Util.html_escape(ENV['HORO_PROJECT_NAME']) %> <%= ERB::Util.html_escape(ENV['HORO_PROJECT_VERSION']) %></span><br />
+        <% if project_name %>
+            <div><%= project_name %> <%= project_version %></div>
         <% end %>
+
         <h2>
             <%= h file.name %>
         </h2>
@@ -32,8 +33,9 @@
             </li>
             <li>Last modified: <%= file.file_stat.mtime %></li>
         </ul>
-        <% if ENV['HORO_BADGE_VERSION'] %>
-            <div id="version-badge"><%= ENV['HORO_BADGE_VERSION'] %></div>
+
+        <% if badge_version %>
+            <div id="version-badge"><%= badge_version %></div>
         <% end %>
     </div>
 

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -55,12 +55,26 @@ module SDoc::Helpers
     end
   end
 
-  def horo_canonical_url(canonical_url, context)
-    if context == :index
-      return "#{canonical_url}/"
+  def canonical_url(context)
+    if ENV["HORO_CANONICAL_URL"]
+      if context == :index
+        "#{ENV["HORO_CANONICAL_URL"]}/"
+      else
+        "#{ENV["HORO_CANONICAL_URL"]}/#{context.as_href("")}"
+      end
     end
+  end
 
-    return "#{canonical_url}/#{context.as_href("")}"
+  def project_name
+    @html_safe_project_name ||= h(ENV["HORO_PROJECT_NAME"]) if ENV["HORO_PROJECT_NAME"]
+  end
+
+  def project_version
+    @html_safe_project_version ||= h(ENV["HORO_PROJECT_VERSION"]) if ENV["HORO_PROJECT_VERSION"]
+  end
+
+  def badge_version
+    @html_safe_badge_version ||= h(ENV["HORO_BADGE_VERSION"]) if ENV["HORO_BADGE_VERSION"]
   end
 
 protected

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -89,4 +89,70 @@ describe SDoc::Helpers do
         must_equal %(<base href="../../../" data-current-path="classes/Foo/Bar/Qux.html">)
     end
   end
+
+  describe "#canonical_url" do
+    it "returns a URL based on ENV['HORO_CANONICAL_URL'] for an RDoc::Context" do
+      context = rdoc_top_level_for(<<~RUBY).find_module_named("Foo::Bar::Qux")
+        module Foo; module Bar; module Qux; end; end; end
+      RUBY
+
+      with_env("HORO_CANONICAL_URL" => "https://canonical") do
+        _(@helpers.canonical_url(context)).must_equal "https://canonical/classes/Foo/Bar/Qux.html"
+      end
+    end
+
+    it "returns a URL based on ENV['HORO_CANONICAL_URL'] for the :index context" do
+      with_env("HORO_CANONICAL_URL" => "https://canonical") do
+        _(@helpers.canonical_url(:index)).must_equal "https://canonical/"
+      end
+    end
+
+    it "returns nil when ENV['HORO_CANONICAL_URL'] is not set" do
+      with_env("HORO_CANONICAL_URL" => nil) do
+        _(@helpers.canonical_url(:index)).must_be_nil
+      end
+    end
+  end
+
+  describe "#project_name" do
+    it "returns escaped name from ENV['HORO_PROJECT_NAME']" do
+      with_env("HORO_PROJECT_NAME" => "Ruby & Rails") do
+        _(@helpers.project_name).must_equal "Ruby &amp; Rails"
+      end
+    end
+
+    it "returns nil when ENV['HORO_PROJECT_NAME'] is not set" do
+      with_env("HORO_PROJECT_NAME" => nil) do
+        _(@helpers.project_name).must_be_nil
+      end
+    end
+  end
+
+  describe "#project_version" do
+    it "returns escaped version from ENV['HORO_PROJECT_VERSION']" do
+      with_env("HORO_PROJECT_VERSION" => "~> 1.0.0") do
+        _(@helpers.project_version).must_equal "~&gt; 1.0.0"
+      end
+    end
+
+    it "returns nil when ENV['HORO_PROJECT_VERSION'] is not set" do
+      with_env("HORO_PROJECT_VERSION" => nil) do
+        _(@helpers.project_version).must_be_nil
+      end
+    end
+  end
+
+  describe "#badge_version" do
+    it "returns escaped version from ENV['HORO_BADGE_VERSION']" do
+      with_env("HORO_BADGE_VERSION" => "~> 1.0.0") do
+        _(@helpers.badge_version).must_equal "~&gt; 1.0.0"
+      end
+    end
+
+    it "returns nil when ENV['HORO_BADGE_VERSION'] is not set" do
+      with_env("HORO_BADGE_VERSION" => nil) do
+        _(@helpers.badge_version).must_be_nil
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,14 @@ require 'sdoc'
 
 require 'minitest/autorun'
 
+def with_env(env, &block)
+  original_env = ENV.to_h
+  ENV.replace(env)
+  block.call
+ensure
+  ENV.replace(original_env)
+end
+
 # Returns an RDoc::TopLevel instance for the given Ruby code.
 def rdoc_top_level_for(ruby_code)
   # RDoc has a lot of internal state that needs to be initialized. The most


### PR DESCRIPTION
This commit adds helpers to access the following values:

* `ENV["HORO_PROJECT_NAME"]`
* `ENV["HORO_PROJECT_VERSION"]`
* `ENV["HORO_BADGE_VERSION"]`
* `ENV["HORO_CANONICAL_URL"]`

The helpers HTML-escape the values, so instead of writing something like:

  ```erb
  <%= h ENV["HORO_PROJECT_NAME"] %>
  ```

We can write:

  ```erb
  <%= project_name %>
  ```