### PR TITLE
Replace `each_letter_group` with `group_by_first_letter`

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -32,13 +32,13 @@
     <!-- Method ref -->
     <div class="sectiontitle">Methods</div>
     <dl class="methods">
-      <% each_letter_group(context.method_list) do |group| %>
-        <dt><%= group[:name] %></dt>
+      <% group_by_first_letter(context.method_list).each do |letter, methods| %>
+        <dt><%= letter %></dt>
         <dd>
           <ul>
-            <% group[:methods].each_with_index do |method, i|  %>
+            <% methods.each_with_index do |method, i| %>
               <%
-                comma = group[:methods].size == i+1 ? '' : ','
+                comma = methods.size == i+1 ? '' : ','
               %>
               <li><%= link_to method.name, method %><%= comma %></li>
             <% end %>

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -1,20 +1,4 @@
 module SDoc::Helpers
-  def each_letter_group(methods, &block)
-    group = {:name => '', :methods => []}
-    methods.sort{ |a, b| a.name <=> b.name }.each do |method|
-      gname = group_name method.name
-      if gname != group[:name]
-        yield group unless group[:methods].size == 0
-        group = {
-          :name => gname,
-          :methods => []
-        }
-      end
-      group[:methods].push(method)
-    end
-    yield group unless group[:methods].size == 0
-  end
-
   # Strips out HTML tags from a given string.
   #
   # Example:
@@ -77,12 +61,9 @@ module SDoc::Helpers
     @html_safe_badge_version ||= h(ENV["HORO_BADGE_VERSION"]) if ENV["HORO_BADGE_VERSION"]
   end
 
-protected
-  def group_name name
-    if match = name.match(/^([a-z])/i)
-      match[1].upcase
-    else
-      '#'
+  def group_by_first_letter(rdoc_objects)
+    rdoc_objects.sort_by(&:name).group_by do |object|
+      object.name[/^[a-z]/i]&.upcase || "#"
     end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -155,4 +155,28 @@ describe SDoc::Helpers do
       end
     end
   end
+
+  describe "#group_by_first_letter" do
+    it "groups RDoc objects by the first letter of their #name" do
+      context = rdoc_top_level_for(<<~RUBY).find_module_named("Foo")
+        module Foo
+          def bar; end
+          def _bar; end
+          def baa; end
+
+          def qux; end
+          def _qux; end
+          def Qux; end
+        end
+      RUBY
+
+      expected = {
+        "#" => [context.find_method("_bar", false), context.find_method("_qux", false)],
+        "B" => [context.find_method("baa", false), context.find_method("bar", false)],
+        "Q" => [context.find_method("Qux", false), context.find_method("qux", false)],
+      }
+
+      _(@helpers.group_by_first_letter(context.method_list)).must_equal expected
+    end
+  end
 end


### PR DESCRIPTION
This commit replaces the `each_letter_group` helper with a `group_by_first_letter` helper.  The `group_by_first_letter` helper serves the same purpose but its implementation is simpler and its output is more easily testable.