### PR TITLE
Factor out `method_source_code_and_url` helper

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -158,39 +158,28 @@
             </div>
           <% end %>
 
-          <% if method.token_stream %>
-            <% markup = method.markup_code %>
+          <% source_code, source_url = method_source_code_and_url(method) %>
+          <% if source_code || source_url %>
             <div class="sourcecode">
-              <%
-                # generate github link
-                github = if options.github
-                  if markup =~ /File\s(\S+), line (\d+)/
-                    path = $1
-                    line = $2.to_i
-                  end
-                  path && github_url(path)
-                else
-                  false
-                end
-
-                ghost = method.instance_of?(RDoc::GhostMethod)
-              %>
               <p class="source-link">
-                <% if !ghost || github %> Source: <% end %>
+                Source:
 
-                <% unless ghost %>
+                <% if source_code %>
                   <a href="javascript:toggleSource('<%= method.aref %>_source')" id="l_<%= method.aref %>_source">show</a>
                 <% end %>
 
-                <% if !ghost && github %> | <% end %>
+                <% if source_code && source_url %> | <% end %>
 
-                <% if github %>
-                  <a href="<%= "#{github}#L#{line}" %>" target="_blank" class="github_url">on GitHub</a>
+                <% if source_url %>
+                  <a href="<%= source_url %>" target="_blank" class="github_url">on GitHub</a>
                 <% end %>
               </p>
-              <div id="<%= method.aref %>_source" class="dyn-source">
-                <pre><code class="ruby"><%= markup %></code></pre>
-              </div>
+
+              <% if source_code %>
+                <div id="<%= method.aref %>_source" class="dyn-source">
+                  <pre><code class="ruby"><%= source_code %></code></pre>
+                </div>
+              <% end %>
             </div>
             <% end %>
           </div>

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -69,4 +69,14 @@ module SDoc::Helpers
       object.name[/^[a-z]/i]&.upcase || "#"
     end
   end
+
+  def method_source_code_and_url(rdoc_method)
+    source_code = rdoc_method.markup_code if rdoc_method.token_stream
+
+    if source_code&.match(/File\s(\S+), line (\d+)/)
+      source_url = github_url($1, line: $2)
+    end
+
+    [(source_code unless rdoc_method.instance_of?(RDoc::GhostMethod)), source_url]
+  end
 end

--- a/lib/sdoc/helpers/github.rb
+++ b/lib/sdoc/helpers/github.rb
@@ -1,7 +1,8 @@
 module SDoc::Helpers::GitHub
-  def github_url(relative_path)
+  def github_url(relative_path, line: nil)
     return unless github?
-    "https://github.com/#{github_repository}/blob/#{git_head_sha1}/#{relative_path}"
+    line = "#L#{line}" if line
+    "https://github.com/#{github_repository}/blob/#{git_head_sha1}/#{relative_path}#{line}"
   end
 
   def github?

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -91,6 +91,11 @@ describe SDoc::Helpers do
 
       _(@helpers.github_url("foo/bar/qux.rb")).must_be_nil
     end
+
+    it "supports :line option" do
+      _(@helpers.github_url("foo/bar/qux.rb", line: 123)).
+        must_match %r"\Ahttps://github.com/.+/foo/bar/qux\.rb#L123\z"
+    end
   end
 
   describe "#link_to" do
@@ -239,6 +244,72 @@ describe SDoc::Helpers do
       }
 
       _(@helpers.group_by_first_letter(context.method_list)).must_equal expected
+    end
+  end
+
+  describe "#method_source_code_and_url" do
+    before :each do
+      @helpers.options.github = true
+    end
+
+    it "returns source code and GitHub URL for a given RDoc::AnyMethod" do
+      method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo").find_method("bar", false)
+        module Foo # line 1
+          def bar # line 2
+            # line 3
+          end
+        end
+      RUBY
+
+      source_code, source_url = @helpers.method_source_code_and_url(method)
+
+      _(source_code).must_match %r"# File .+\.rb, line 2\b"
+      _(source_code).must_include "line 3"
+      _(source_url).must_match %r"\Ahttps://github.com/.+\.rb#L2\z"
+    end
+
+    it "returns nil source code when given method is an RDoc::GhostMethod" do
+      method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo").find_method("bar", false)
+        module Foo # line 1
+          ##
+          # :method: bar
+        end
+      RUBY
+
+      source_code, source_url = @helpers.method_source_code_and_url(method)
+
+      _(source_code).must_be_nil
+      _(source_url).must_match %r"\Ahttps://github.com/.+\.rb#L3\z"
+    end
+
+    it "returns nil source code when given method is an alias" do
+      method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo").find_method("bar", false)
+        module Foo # line 1
+          def qux; end
+          alias bar qux
+        end
+      RUBY
+
+      source_code, source_url = @helpers.method_source_code_and_url(method)
+
+      _(source_code).must_be_nil
+      # Unfortunately, source_url is also nil because RDoc does not provide the
+      # source code location in this case.
+    end
+
+    it "returns nil GitHub URL when options.github is false" do
+      @helpers.options.github = false
+
+      method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo").find_method("bar", false)
+        module Foo # line 1
+          def bar; end # line 2
+        end
+      RUBY
+
+      source_code, source_url = @helpers.method_source_code_and_url(method)
+
+      _(source_code).must_match %r"# File .+\.rb, line 2\b"
+      _(source_url).must_be_nil
     end
   end
 end


### PR DESCRIPTION
This commit factors a `method_source_code_and_url` helper out from `_context.rhtml`.  This cleans up the template and allows the underlying logic to be tested.