### PR TITLE
Skip rendering parent class when superclass is nil

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -31,11 +31,11 @@
         <h2>
             <span class="type"><%= klass.module? ? 'Module' : 'Class' %></span>
             <%= h klass.full_name %>
-            <% if klass.type == 'class' %>
+            <% if klass.type == "class" && klass.superclass %>
                 <span class="parent">&lt;
                     <% if klass.superclass.is_a?(String) %>
                     <%= klass.superclass %>
-                    <% elsif klass.superclass %>
+                    <% else %>
                     <%= link_to klass.superclass.full_name, klass.superclass %>
                     <% end %>
                 </span>


### PR DESCRIPTION
`RDoc::ClassModule#superclass` will be `nil` for `BasicObject`.  This commit prevents a dangling `&lt;` in that case.