### PR TITLE
Move alias listing closer to method name

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -137,24 +137,24 @@
           </h3>
           <%= link_to "Link", method, class: "permalink", name: method.aref %>
 
-          <% if method.comment %>
-            <div class="description">
-              <%= method.description.strip %>
-            </div>
-          <% end %>
-
           <% unless method.aliases.empty? %>
-            <div class="aka">
+            <p class="aka">
               Also aliased as:
               <%# Sometimes a parent cannot be determined. See ruby/rdoc@85ebfe13dc. %>
-              <%= method.aliases.map { |aka| link_to aka.name, (aka if aka.parent) }.join(", ") %>
-            </div>
+              <%= method.aliases.map { |aka| link_to aka.name, (aka if aka.parent) }.join(", ") %>.
+            </p>
           <% end %>
 
           <% if alias_for = method.is_alias_for then %>
-            <div class="aka">
+            <p class="aka">
               Alias for:
-              <%= link_to alias_for.name, alias_for %>
+              <%= link_to alias_for.name, alias_for %>.
+            </p>
+          <% end %>
+
+          <% if method.comment %>
+            <div class="description">
+              <%= method.description.strip %>
             </div>
           <% end %>
 

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -349,10 +349,8 @@ tt {
 }
 
 .method .aka {
-  margin-top: 0.3em;
-  margin-left: 1em;
+  margin-left: 1.2em;
   font-style: italic;
-  text-indent: 2em;
 }
 
 .method .source-link


### PR DESCRIPTION
This commit moves the method alias listing above the method description, putting it closer to the method name.  Since the aliases now precede the description, they cannot be misinterpreted as part of the description, so there is no need to further indent them.

| Before | After |
| --- | --- |
| ![before1](https://github.com/rails/sdoc/assets/771968/93582a27-e22a-4b06-91c9-7dea16b0f3c5) | ![after1](https://github.com/rails/sdoc/assets/771968/81ee0df4-05d4-4761-bc3f-113cce0d0b27) |
| ![before2a](https://github.com/rails/sdoc/assets/771968/939b0588-e2e9-4fa4-b830-68a32cc5e9b3) ![before2b](https://github.com/rails/sdoc/assets/771968/bda2486c-ce02-43f6-aaf0-8fd0f784e47c) | ![after2a](https://github.com/rails/sdoc/assets/771968/5ac6c9d2-4a31-4335-a779-af10acb739f2) ![after2b](https://github.com/rails/sdoc/assets/771968/aa01877f-bbce-4251-9cf6-90895c376521) |
