### PR TITLE
Unlink unintentional autolinked code ref links

### DIFF
--- a/lib/sdoc/postprocessor.rb
+++ b/lib/sdoc/postprocessor.rb
@@ -11,6 +11,7 @@ module SDoc::Postprocessor
 
     rebase_urls!(document)
     version_rails_guides_urls!(document)
+    unlink_unintentional_ref_links!(document)
     highlight_code_blocks!(document)
 
     document.to_s
@@ -67,6 +68,14 @@ module SDoc::Postprocessor
     end
 
     uri.to_s
+  end
+
+  def unlink_unintentional_ref_links!(document)
+    document.css(".description a[href^='classes/'] > code:only-child > text()").each do |text_node|
+      if text_node.inner_text.match?(/\A[A-Z](?:[A-Z]+|[a-z]+)\z/)
+        text_node.parent.parent.replace(text_node)
+      end
+    end
   end
 
   def highlight_code_blocks!(document)

--- a/spec/postprocessor_spec.rb
+++ b/spec/postprocessor_spec.rb
@@ -61,6 +61,36 @@ describe SDoc::Postprocessor do
       end
     end
 
+    it "unlinks unintentional autolinked code ref links in descriptions" do
+      rendered = <<~HTML
+        <base href="../" data-current-path="classes/Foo.html">
+
+        <div class="description">
+          <a href="Rails.html"><code>Rails</code></a>
+          <a href="ERB.html"><code>ERB</code></a>
+
+          <a href="Rails.html"><code>::Rails</code></a>
+          <a href="FooBar.html"><code>FooBar</code></a>
+        </div>
+
+        <a href="Nav.html"><code>Nav</code></a>
+      HTML
+
+      expected = <<~HTML
+        <div class="description">
+          Rails
+          ERB
+
+          <a href="classes/Rails.html"><code>::Rails</code></a>
+          <a href="classes/FooBar.html"><code>FooBar</code></a>
+        </div>
+
+        <a href="classes/Nav.html"><code>Nav</code></a>
+      HTML
+
+      _(SDoc::Postprocessor.process(rendered)).must_include expected
+    end
+
     it "highlights code blocks" do
       rendered = <<~HTML
         <div class="description">


### PR DESCRIPTION
RDoc can be overzealous when autolinking words that look like module names.  For example, autolinking every occurrence of "Rails" or "ERB".

This commit uses postprocessing to unlink autolinked code ref links that appear to be unintentional.  If a link's text is an uppercase letter followed by either all lowercase letters (e.g. "Rails") or all uppercase letters (e.g. "ERB"), then it's assumed the link is unintentional, and the link is replaced with the just its text.

These kinds of modules can still be linked by prepending the module namespace (e.g. "::ERB" or "ActionView::Template::Handlers::ERB"), or by manually linking the text (e.g. "{Rails}[rdoc-ref:Rails]").


| Before | After |
| --- | --- |
| ![before1](https://github.com/rails/sdoc/assets/771968/448f92fb-b194-42d0-b22a-e4e89c308de9) | ![after1](https://github.com/rails/sdoc/assets/771968/e30e2413-9ea0-43ad-8cb2-8f5a2cdf8422) |
| ![before2](https://github.com/rails/sdoc/assets/771968/66db82fd-a2a0-4b59-a59a-556b58c48160) | ![after2](https://github.com/rails/sdoc/assets/771968/489c4655-10d6-435d-a0e5-ad4f8ab6f154) |
