### PR TITLE
Style unstyled code ref links

### DIFF
--- a/lib/sdoc/postprocessor.rb
+++ b/lib/sdoc/postprocessor.rb
@@ -12,6 +12,7 @@ module SDoc::Postprocessor
     rebase_urls!(document)
     version_rails_guides_urls!(document)
     unlink_unintentional_ref_links!(document)
+    style_ref_links!(document)
     highlight_code_blocks!(document)
 
     document.to_s
@@ -74,6 +75,15 @@ module SDoc::Postprocessor
     document.css(".description a[href^='classes/'] > code:only-child > text()").each do |text_node|
       if text_node.inner_text.match?(/\A[A-Z](?:[A-Z]+|[a-z]+)\z/)
         text_node.parent.parent.replace(text_node)
+      end
+    end
+  end
+
+  def style_ref_links!(document)
+    document.css(".description a[href^='classes/']:has(> text():only-child)").each do |element|
+      text = element.inner_text
+      if !text.include?(" ") || text.match?(/\S\(/)
+        element.inner_html = "<code>#{element.inner_html}</code>"
       end
     end
   end

--- a/spec/postprocessor_spec.rb
+++ b/spec/postprocessor_spec.rb
@@ -91,6 +91,42 @@ describe SDoc::Postprocessor do
       _(SDoc::Postprocessor.process(rendered)).must_include expected
     end
 
+    it "styles unstyled code ref links in descriptions" do
+      rendered = <<~HTML
+        <base href="../" data-current-path="classes/Foo.html">
+
+        <div class="description">
+          <a href="/classes/Bar/Qux.html">Qux</a>
+          <a href="Bar/Qux.html">Qux</a>
+          <a href="#method-i-bar-3F.html">Foo#bar?(qux, &amp;block)</a>
+          <a href="#method-i-2A_bar-21.html">*_bar!</a>
+
+          <a href="https://example.com/Qux.html">Qux</a>
+          <a href="Bar/Qux.html">Not Code</a>
+          <a href="Bar/Qux.html">(also) not code</a>
+        </div>
+
+        <a href="/classes/Permalink.html">Permalink</a>
+      HTML
+
+      expected = <<~HTML
+        <div class="description">
+          <a href="classes/Bar/Qux.html"><code>Qux</code></a>
+          <a href="classes/Bar/Qux.html"><code>Qux</code></a>
+          <a href="classes/Foo.html#method-i-bar-3F.html"><code>Foo#bar?(qux, &amp;block)</code></a>
+          <a href="classes/Foo.html#method-i-2A_bar-21.html"><code>*_bar!</code></a>
+
+          <a href="https://example.com/Qux.html">Qux</a>
+          <a href="classes/Bar/Qux.html">Not Code</a>
+          <a href="classes/Bar/Qux.html">(also) not code</a>
+        </div>
+
+        <a href="classes/Permalink.html">Permalink</a>
+      HTML
+
+      _(SDoc::Postprocessor.process(rendered)).must_include expected
+    end
+
     it "highlights code blocks" do
       rendered = <<~HTML
         <div class="description">


### PR DESCRIPTION
RDoc does not provide syntax to style manual code ref links with `<code></code>`.  Wrapping code ref links in `<tt></tt>` or `++` does not give the desired result.  For example,

  ```ruby
  # {<tt>Rails</tt>}[rdoc-ref:Rails]
  ```

is rendered as

  ```html
  {<code>Rails</code><a href="..."><code>}</code></a>
  ```

and

  ```ruby
  # <tt>{Rails}[rdoc-ref:Rails]</tt>
  ```

is rendered as

  ```html
  <code>{Rails}[rdoc-ref:Rails]</code>
  ```

This commit uses postprocessing to style unstyled code ref links that look like code.  If the link text does not contain a space or if it matches `/\S\(/` (e.g. `foo(bar, &block)`), it is assumed to be code, and the text is then wrapped with `<code></code>`.

This complements 4837fea087618a3811f246d466a5af9346802369 in that it allows manual code ref links to single-word modules to be styled as if they were autolinks.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/2bdf1131-f20b-430d-8a97-811b828f75a0) | ![after](https://github.com/rails/sdoc/assets/771968/b223b594-80a3-4191-b76b-5ad52387815e) |
