### PR TITLE
Include project name and version in default title

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,7 @@ class RailsTask < Rails::API::EdgeTask
   def configure_sdoc
     options << "--root" << "rails"
     super
+    self.title = nil # Use default title for local testing.
   end
 
   def rails_version

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -46,19 +46,23 @@ class RDoc::Generator::SDoc
 
   def self.setup_options(options)
     opt = options.option_parser
+
     opt.separator nil
     opt.separator "SDoc generator options:"
+
     opt.separator nil
     opt.on("--github", "-g",
             "Generate links to github.") do |value|
       options.github = true
     end
-    opt.separator nil
 
+    opt.separator nil
     opt.on("--version", "-v", "Output current version") do
       puts SDoc::VERSION
       exit
     end
+
+    options.title = [ENV["HORO_PROJECT_NAME"], ENV["HORO_BADGE_VERSION"], "API documentation"].compact.join(" ")
   end
 
   def initialize(store, options)

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -44,4 +44,28 @@ describe RDoc::Generator::SDoc do
       _(parse_options("-g").github).must_equal true
     end
   end
+
+  describe "options.title" do
+    it "includes ENV['HORO_PROJECT_NAME'] and ENV['HORO_BADGE_VERSION'] by default" do
+      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_BADGE_VERSION" => "v2.0") do
+        _(parse_options().title).must_equal "My Gem v2.0 API documentation"
+      end
+
+      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_BADGE_VERSION" => nil) do
+        _(parse_options().title).must_equal "My Gem API documentation"
+      end
+
+      with_env("HORO_PROJECT_NAME" => nil, "HORO_BADGE_VERSION" => "v2.0") do
+        _(parse_options().title).must_equal "v2.0 API documentation"
+      end
+
+      with_env("HORO_PROJECT_NAME" => nil, "HORO_BADGE_VERSION" => nil) do
+        _(parse_options().title).must_equal "API documentation"
+      end
+    end
+
+    it "can be overridden" do
+      _(parse_options("--title", "Docs Docs Docs!").title).must_equal "Docs Docs Docs!"
+    end
+  end
 end


### PR DESCRIPTION
This adds `ENV["HORO_PROJECT_NAME"]` and `ENV["HORO_BADGE_VERSION"]` to the default site title.  For example, if `ENV["HORO_PROJECT_NAME"]` is "Ruby on Rails" and `ENV["HORO_BADGE_VERSION"]` is "v7.0.0", then the default site title will be "Ruby on Rails v7.0.0 API documentation".