### PR TITLE
Include site title in page titles

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="<%= @options.charset %>">
-    <title><%= h klass.full_name %></title>
+    <title><%= page_title klass.full_name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:context => klass, :tree_keys => klass.full_name.split('::') } %>
 

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="<%= @options.charset %>">
-    <title><%= h file.name %></title>
+    <title><%= page_title file.name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:context => file, :tree_keys => [] } %>
 </head>

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="<%= @options.charset %>">
-    <title><%= @options.title %></title>
+    <title><%= page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:context => :index, tree_keys: []} %>
 </head>

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -72,6 +72,10 @@ module SDoc::Helpers
     @html_safe_badge_version ||= h(ENV["HORO_BADGE_VERSION"]) if ENV["HORO_BADGE_VERSION"]
   end
 
+  def page_title(title = nil)
+    h [title, @options.title].compact.join(" - ")
+  end
+
   def group_by_first_letter(rdoc_objects)
     rdoc_objects.sort_by(&:name).group_by do |object|
       object.name[/^[a-z]/i]&.upcase || "#"

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -245,6 +245,21 @@ describe SDoc::Helpers do
     end
   end
 
+  describe "#page_title" do
+    it "includes options.title" do
+      @helpers.options.title = "My Docs"
+
+      _(@helpers.page_title).must_equal "My Docs"
+      _(@helpers.page_title("Foo")).must_equal "Foo - My Docs"
+    end
+
+    it "escapes the title" do
+      @helpers.options.title = "Docs & Stuff"
+
+      _(@helpers.page_title("Foo<Bar>")).must_equal "Foo&lt;Bar&gt; - Docs &amp; Stuff"
+    end
+  end
+
   describe "#group_by_first_letter" do
     it "groups RDoc objects by the first letter of their #name" do
       context = rdoc_top_level_for(<<~RUBY).find_module_named("Foo")


### PR DESCRIPTION
This adds the site title to each page's title.  When using the default site title, this will incorporate `ENV["HORO_PROJECT_NAME"]` and `ENV["HORO_BADGE_VERSION"]` into the page title.  For example,

  ```html
  <title>ActiveRecord::Base</title>
  ```

will become

  ```html
  <title>ActiveRecord::Base - Ruby on Rails v7.0.0 API documentation</title>
  ```

The intent is to give search engines more context and to differentiate between versions of the documentation.