### PR TITLE
Refine meta description

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -8,11 +8,9 @@
 
     <meta property="og:title" value="<%= og_title klass.full_name %>">
 
-  <% unless (description = klass.description).empty? %>
-    <% human_desc = truncate(strip_tags(description.gsub("\n", " ").strip)) %>
-    <meta name="description" content="<%= human_desc %>">
-    <meta property="og:description" content="<%= human_desc %>">
-  <% end %>
+    <% if description = page_description(klass.description) %>
+    <meta name="description" property="og:description" content="<%= description %>">
+    <% end %>
 
     <meta name="keywords" content="<%= klass.full_name %> class, <%= klass.method_list.map(&:name).join(", ") %>">
 </head>


### PR DESCRIPTION
Prior to this commit, the value of the `description` and `og:description` meta tags were generated by taking the first 200 characters of a module's comment and then further truncating until the last "." character (if possible).  That approach causes headlines and non-prose elements to be included in the description.  For example, for `ActionController::Base` which has an "Action Controller Base" headline, the description was:

> Action Controller Base  Action Controllers are the core of a web request in Rails.

And for `ActionController::HttpAuthentication::Basic` which begins with a code example, the description was:

> HTTP Basic authentication  Simple Basic example   class PostsController < ApplicationController http_basic_authenticate_with name: "dhh", password: "secret", except: :index  .

This commit uses a slightly different approach to generate the description: it extracts the description from the leading paragraph of the module's comment.  Headlines are ignored, and if no leading paragraph exists, then no description is generated.

Additionally, the description is truncated as close to the length limit as possible while respecting word boundaries, and the length limit has been updated to 160 characters since that is the current SEO recommendation.

So the description for `ActionController::Base` becomes:

> Action Controllers are the core of a web request in Rails. They are made up of one or more actions that are executed on request and then either it renders a...

And the description for `ActionController::HttpAuthentication::Basic` is omitted.