### PR TITLE
Remove `keywords` meta tag

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -7,12 +7,9 @@
     <%= include_template '_head.rhtml', {:context => klass, :tree_keys => klass.full_name.split('::') } %>
 
     <meta property="og:title" value="<%= og_title klass.full_name %>">
-
     <% if description = page_description(klass.description) %>
     <meta name="description" property="og:description" content="<%= description %>">
     <% end %>
-
-    <meta name="keywords" content="<%= klass.full_name %> class, <%= klass.method_list.map(&:name).join(", ") %>">
 </head>
 
 <body>


### PR DESCRIPTION
The `keywords` meta tag is ignored by major search engines.  Furthermore, it is difficult to generate significant, unique (i.e. not spammy) keywords from method names.  Consider the keywords generated for the `ActiveModel::Dirty` module:

> ActiveModel::Dirty class, \*\_previously_changed?, \*\_changed?, \*\_change, \*\_will\_change!, \*\_was, \*\_previous_change, \*\_previously\_was, restore\_\*!, clear\_\*\_change, changes_applied, changed?, changed, attribute_changed?, attribute_was, attribute_previously_changed?, attribute_previously_was, restore_attributes, clear_changes_information, clear_attribute_changes, changed_attributes, changes, previous_changes

The keywords include "\*_changed?", "\*_change", "changed?", "changed", and "changes".  If a search engine _were_ to evaluate these keywords, it would likely judge them as spam.

Given the tag's ineffectiveness, this commit simply removes it.