### PR TITLE
Add required Open Graph meta tags

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -1,8 +1,10 @@
 <%= base_tag_for_context(context) %>
+
 <link rel="stylesheet" href="/css/reset.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="/css/panel.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="/css/main.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="/css/highlight.css" type="text/css" media="screen" />
+
 <script src="/js/jquery-3.5.1.min.js" type="text/javascript" charset="utf-8"></script>
 <script src="/js/main.js" type="text/javascript" charset="utf-8"></script>
 <script src="/js/@hotwired--turbo.js" type="text/javascript" charset="utf-8"></script>
@@ -11,6 +13,10 @@
 <script src="/panel/tree.js" type="text/javascript" charset="utf-8"></script>
 <script src="/js/searchdoc.js" type="text/javascript" charset="utf-8"></script>
 <meta name="data-tree-keys" content='<%= tree_keys %>'>
+
 <% if canonical = canonical_url(context) %>
 <link rel="canonical" href="<%= canonical %>" />
+<meta property="og:url" content="<%= canonical %>">
+<meta property="og:image" content="<%= canonical_url("/i/logo.svg") %>">
 <% end %>
+<meta property="og:type" content="article">

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -24,8 +24,9 @@ module SDoc::Helpers
     %(<base href="./#{relative_root}" data-current-path="#{context&.path}">)
   end
 
-  def canonical_url(context)
-    "#{ENV["HORO_CANONICAL_URL"]}/#{context&.path}" if ENV["HORO_CANONICAL_URL"]
+  def canonical_url(path = nil)
+    path = path.path if path.is_a?(RDoc::Context)
+    "#{ENV["HORO_CANONICAL_URL"]}/#{path&.delete_prefix("/")}" if ENV["HORO_CANONICAL_URL"]
   end
 
   def project_name

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -167,7 +167,14 @@ describe SDoc::Helpers do
       end
     end
 
-    it "returns a URL based on ENV['HORO_CANONICAL_URL'] for nil context" do
+    it "returns a URL based on ENV['HORO_CANONICAL_URL'] for a path" do
+      with_env("HORO_CANONICAL_URL" => "https://canonical") do
+        _(@helpers.canonical_url("/path/to/foo")).must_equal "https://canonical/path/to/foo"
+        _(@helpers.canonical_url("path/to/foo")).must_equal "https://canonical/path/to/foo"
+      end
+    end
+
+    it "returns a URL based on ENV['HORO_CANONICAL_URL'] for nil" do
       with_env("HORO_CANONICAL_URL" => "https://canonical") do
         _(@helpers.canonical_url(nil)).must_equal "https://canonical/"
       end


### PR DESCRIPTION
The [Open Graph spec](https://ogp.me/) requires four meta tags: `og:title`, `og:type`, `og:image`, and `og:url`.  We already include `og:title`, as well as `og:description`, so we may as well include the remaining three.

`og:type` can be one of a few predefined values.  The two values that are most suitable are `article` and `website`.  This commit chooses `article` because the `article` type supports additional optional metadata (for example, `article:modified_time`), whereas the `website` type does not.

This commit uses `/i/logo.svg` for `og:image`.  Note that `og:image` must be an abolute URL, so `/i/logo.svg` is combined with `ENV["HORO_CANONICAL_URL"]`.

Lastly, this commit uses a URL based on `ENV["HORO_CANONICAL_URL"]` for `og:url`.