### PR TITLE
Add `article:modified_time` meta tag

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -20,3 +20,4 @@
 <meta property="og:image" content="<%= canonical_url("/i/logo.svg") %>">
 <% end %>
 <meta property="og:type" content="article">
+<meta property="article:modified_time" content="<%= og_modified_time %>">

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -1,6 +1,6 @@
 module SDoc::Helpers
-  require_relative "helpers/github"
-  include SDoc::Helpers::GitHub
+  require_relative "helpers/git"
+  include SDoc::Helpers::Git
 
   def link_to(text, url, html_attributes = {})
     return h(text) if url.nil?
@@ -48,6 +48,10 @@ module SDoc::Helpers
   def og_title(title)
     project = [project_name, badge_version].join(" ").strip
     "#{h title}#{" (#{project})" unless project.empty?}"
+  end
+
+  def og_modified_time
+    git_head_timestamp if git?
   end
 
   def page_description(leading_html, max_length: 160)

--- a/lib/sdoc/helpers/git.rb
+++ b/lib/sdoc/helpers/git.rb
@@ -1,4 +1,4 @@
-module SDoc::Helpers::GitHub
+module SDoc::Helpers::Git
   def github_url(relative_path, line: nil)
     return unless github?
     line = "#L#{line}" if line
@@ -21,6 +21,14 @@ module SDoc::Helpers::GitHub
   def git_head_sha1
     @git_head_sha1 ||= Dir.chdir(@options.root) do
       `git rev-parse HEAD`.chomp
+    end
+  end
+
+  attr_writer :git_head_timestamp
+
+  def git_head_timestamp
+    @git_head_timestamp ||= Dir.chdir(@options.root) do
+      `git show -s --format=%cI HEAD` .chomp
     end
   end
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -270,6 +270,26 @@ describe SDoc::Helpers do
     end
   end
 
+  describe "#og_modified_time" do
+    it "returns the commit time of the most recent commit in HEAD" do
+      @helpers.git_bin_path = "path/to/git"
+      @helpers.git_head_timestamp = "1999-12-31T12:34:56Z"
+
+      _(@helpers.og_modified_time).must_equal "1999-12-31T12:34:56Z"
+    end
+
+    it "returns the commit time of the most recent commit in HEAD (smoke test)" do
+      _(@helpers.og_modified_time).
+        must_match %r"\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}\z"
+    end
+
+    it "returns nil when git is not installed" do
+      @helpers.git_bin_path = ""
+
+      _(@helpers.og_modified_time).must_be_nil
+    end
+  end
+
   describe "#page_description" do
     it "extracts the description from the leading paragraph" do
       _(@helpers.page_description(<<~HTML)).must_equal "leading"


### PR DESCRIPTION
This commit adds the `article:modified_time` meta tag using the commit time from the most recent commit of the code branch.

This _might_ help search engines prioritize newer doc versions as old doc version are no longer updated.