### PR TITLE
Add initial dark mode support

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -1,10 +1,20 @@
+:root {
+  --text-color: #3B3B3B;
+  --background-color: #fff;
+  --border-color: #ccc;
+  --code-background-color: #eee;
+  --source-background-color: #fffde8;
+  --method-heading-color: #555;
+}
+
 html {
   height: 100%;
 }
+
 body {
   font-family: "Helvetica Neue", Arial, sans-serif;
-  background: #FFF;
-  color: #3B3B3B;
+  background: var(--background-color);
+  color: var(--text-color);
   margin: 0px;
   font-size: 15px;
   line-height: 1.25em;
@@ -95,7 +105,7 @@ h2 {
 
 h3 {
     font-size: 1.4em;
-    color:#555;
+    color: var(--method-heading-color);
     margin: 1.4em 0 0.7em 0;
     font-weight: normal;
 }
@@ -238,7 +248,7 @@ pre
   font-size: 1.2em;
   padding: 0 0 0.25em 0;
   font-weight: bold;
-  border-bottom: 1px solid #000;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .contenttitle {
@@ -275,7 +285,7 @@ tt {
 }
 
 .dyn-source {
-  background: #fffde8;
+  background: var(--source-background-color);
   color: #000;
   border: #ffe0bb dotted 1px;
   margin: 0.5em 2em 0.5em 0;
@@ -284,7 +294,7 @@ tt {
 
 .description pre {
   padding: 1em 1.2em;
-  background: #EEEEEE;
+  background: var(--code-background-color);
   border-radius: 10px;
   font-size: 15px;
 }
@@ -309,7 +319,7 @@ tt {
     padding: 0 0 0.2em 0;
     margin-bottom: 0.8em;
     font-size: 1.1em;
-    color:#333;
+    color: var(--heading-color);
 }
 .method .method-title {
     border-bottom: 1px dotted #666;
@@ -374,9 +384,8 @@ tt {
 }
 
 p code {
-  background: #eeeeee;
-  border-radius: 2px;
-  border: 1px solid #dddddd;
+  background: var(--code-background-color);
+  border-radius: 5px;
   font-family: Consolas, Menlo, Courier, monospace;
   font-size: 14px;
   margin-bottom: 1px;
@@ -447,7 +456,6 @@ a.back-to-top.show {
   visibility: visible;
 }
 
-
 /*
  * More-Less widget
  */
@@ -484,4 +492,19 @@ details.more-less[open] summary::marker {
 details.more-less:not([open]) .more-less__less,
 details.more-less[open] .more-less__more {
   display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text-color: #ddd;
+    --background-color: #222222;
+    --border-color: #444;
+    --code-background-color: #000000;
+    --source-background-color: #000000;
+    --method-heading-color: #ccc;
+  }
+
+  body {
+    --link-color: #ee3f3f;
+  }
 }

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -1,4 +1,10 @@
 /* Panel (begin) */
+:root {
+  --panel-hover-background-color: #d0d0d0;
+  --panel-alternate-background-color: #F0EFEF;
+  --panel-current-background-color: #B61D1D;
+  --panel-highlight-color: #000;
+}
     .panel_checkbox, .panel_mobile_button, .panel_mobile_button_close
     {
         display: none;
@@ -82,11 +88,11 @@
         top: 0;
         width: 300px;
         height: 100%;
-        background: #FFF;
+        background: var(--background-color);
         z-index: 200;
         font-family: "Helvetica Neue", "Arial", sans-serif;
         overflow-x: hidden;
-        border-right: 1px #ccc solid;
+        border-right: 1px solid var(--border-color);
         line-height: 1;
     }
 
@@ -131,7 +137,7 @@
     /* Header with search box (begin) */
         .panel .header
         {
-            background: white url(../i/search.svg) no-repeat;
+            background: var(--background-color) url(../i/search.svg) no-repeat;
             background-position: 5px;
             box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
             height: 40px;
@@ -162,6 +168,8 @@
             margin: 0;
             margin-left: 25px;
             outline: none;
+            background: var(--background-color);
+            color: var(--text-color);
         }
 
         @media (max-width: 599px) {
@@ -205,14 +213,14 @@
         }
 
         .panel .result ul li:nth-child(2n) {
-            background: #F0EFEF;
+            background: var(--panel-alternate-background-color);
         }
 
         .panel .result ul li h1
         {
             font-size: 13px;
             font-weight: normal;
-            color: #333;
+            color: var(--text-color);
             margin-top: 0;
             margin-bottom: 2px;
             white-space: nowrap;
@@ -221,7 +229,7 @@
         .panel .result ul li p
         {
             font-size: 11px;
-            color: #333;
+            color: var(--text-color);
             margin-bottom: 2px;
             white-space: nowrap;
         }
@@ -234,12 +242,12 @@
 
         .panel .result ul li b
         {
-            color: #000;
+            color: var(--panel-highlight-color);
         }
 
         .panel .result ul li.current
         {
-            background: #B61D1D;
+            background: var(--panel-current-background-color);
         }
 
         .panel .result ul li.current h1,
@@ -263,12 +271,12 @@
         .panel .result ul li:hover,
         .panel .result ul li.selected
         {
-            background: #d0d0d0;
+            background: var(--panel-hover-background-color);
         }
 
         .panel .result ul li.current:hover
         {
-            background: #B61D1D;
+            background: var(--panel-current-background-color);
         }
 
         .panel .result ul li .badge
@@ -345,7 +353,7 @@
     /* Tree (begin) */ /**/
         .panel .tree
         {
-            background: white;
+            background: var(--background-color);
             position: relative;
             bottom: 0;
             left: 0;
@@ -402,7 +410,7 @@
         {
             font-size: 13px;
             font-weight: normal;
-            color: #000;
+            color: var(--text-color);
             margin-top: 0;
             margin-bottom: 2px;
             white-space: nowrap;
@@ -441,7 +449,7 @@
 
         .panel .tree ul li.current
         {
-            background: #B61D1D;
+            background: var(--panel-current-background-color);
         }
 
         .panel .tree ul li.current .icon
@@ -474,18 +482,32 @@
 
         .panel .tree ul li:hover
         {
-            background: #d0d0d0;
+            background: var(--panel-hover-background-color);
         }
 
         .panel .tree ul li.current:hover
         {
-            background: #B61D1D;
+            background: var(--panel-current-background-color);
         }
 
         .panel .tree .stopper
         {
             display: none;
         }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --panel-hover-background-color: #3b3b3b;
+                --panel-alternate-background-color: #000000;
+                --panel-highlight-color: #fff;
+            }
+
+            .panel .tree ul:first-child {
+                background: url(../i/dark/tree_bg.svg);
+                background-size: 1px 60px;
+            }
+        }
+
     /* Tree (end) */ /**/
 
 /* Panel (end) */

--- a/lib/rdoc/generator/template/rails/resources/i/dark/tree_bg.svg
+++ b/lib/rdoc/generator/template/rails/resources/i/dark/tree_bg.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1 60" style="enable-background:new 0 0 1 60;" xml:space="preserve">
+<style type="text/css">
+  .st0{fill:#000000;}
+</style>
+<rect class="st0" width="1" height="30"/>
+</svg>


### PR DESCRIPTION
Most dark mode colors are copied from the Rails guides.

<img width="983" alt="image" src="https://github.com/rails/sdoc/assets/28561/3ac58e94-a454-4716-84a0-43eee4a83103">
