### PR TITLE
Prefer `ENV["HORO_BADGE_VERSION"]` version in banner

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -20,7 +20,10 @@
 
     <div class="banner">
         <% if project_name %>
-            <div><%= project_name %> <%= project_version %></div>
+            <div>
+                <%= project_name %>
+                <span title="<%= project_git_head %>"><%= badge_version || project_version %></span>
+            </div>
         <% end %>
 
         <h2>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -17,7 +17,10 @@
 
     <div class="banner">
         <% if project_name %>
-            <div><%= project_name %> <%= project_version %></div>
+            <div>
+                <%= project_name %>
+                <span title="<%= project_git_head %>"><%= badge_version || project_version %></span>
+            </div>
         <% end %>
 
         <h2>

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -15,7 +15,10 @@
 
     <div class="banner">
         <% if project_name %>
-            <div><%= project_name %> <%= project_version %></div>
+            <div>
+                <%= project_name %>
+                <span title="<%= project_git_head %>"><%= badge_version || project_version %></span>
+            </div>
         <% end %>
 
         <h2>

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -41,6 +41,10 @@ module SDoc::Helpers
     h(ENV["HORO_BADGE_VERSION"]) if ENV["HORO_BADGE_VERSION"]
   end
 
+  def project_git_head
+    h "#{git_head_branch}@#{git_head_sha1[0, 12]}" if git?
+  end
+
   def page_title(title = nil)
     h [title, @options.title].compact.join(" - ")
   end

--- a/lib/sdoc/helpers/git.rb
+++ b/lib/sdoc/helpers/git.rb
@@ -20,6 +20,12 @@ module SDoc::Helpers::Git
     Dir.chdir(@options.root) { `git #{command}`.chomp } if git?
   end
 
+  attr_writer :git_head_branch
+
+  def git_head_branch
+    @git_head_branch ||= git_command("rev-parse --abbrev-ref HEAD")
+  end
+
   attr_writer :git_head_sha1
 
   def git_head_sha1

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -229,6 +229,26 @@ describe SDoc::Helpers do
     end
   end
 
+  describe "#project_git_head" do
+    it "returns the branch name and abbreviated SHA1 of the most recent commit in HEAD" do
+      @helpers.git_bin_path = "path/to/git"
+      @helpers.git_head_branch = "1-0-stable"
+      @helpers.git_head_sha1 = "1337c0d3d00d" * 3
+
+      _(@helpers.project_git_head).must_equal "1-0-stable@1337c0d3d00d"
+    end
+
+    it "returns the branch name and abbreviated SHA1 of the most recent commit in HEAD (smoke test)" do
+      _(@helpers.project_git_head).must_match %r"\A.+@[[:xdigit:]]{12}\z"
+    end
+
+    it "returns nil when git is not installed" do
+      @helpers.git_bin_path = ""
+
+      _(@helpers.project_git_head).must_be_nil
+    end
+  end
+
   describe "#page_title" do
     it "includes options.title" do
       @helpers.options.title = "My Docs"


### PR DESCRIPTION
Prior to this commit, the banner at the top of each page would display the value of `ENV["HORO_PROJECT_VERSION"]`.  For Rails, this would either be a bare number, e.g. "7.0.0" without a "v" prefix, or a commit reference, e.g. `main@1234567`.

In contrast, the value of `ENV["HORO_BADGE_VERSION"]` is intended to be more user friendly.  For Rails, it would be e.g. "v7.0.0" or "edge".

This commit changes the banner to display `ENV["HORO_BADGE_VERSION"]` if it is set, and otherwise fall back to `ENV["HORO_PROJECT_VERSION"]`. However, since it may still be valuable for maintainers to know the exact commit that the documentation was generated from, this commit also adds a tooltip to show the abbreviated SHA1 of the commit when hovering over the version.

| Before | After |
| --- | --- |
| ![before1](https://github.com/rails/sdoc/assets/771968/872ff7cd-4848-42aa-a8ae-2ba9cb0e9319) | ![after1a](https://github.com/rails/sdoc/assets/771968/ea6141fa-84b2-485c-bfe1-3d251d0ed287) |
| | ![after1b](https://github.com/rails/sdoc/assets/771968/1fc0acd2-6698-4d37-92f6-9231340fca2c) |
| ![before2](https://github.com/rails/sdoc/assets/771968/4611aa30-1b61-4106-91b1-b2b5cbcd590f) | ![after2a](https://github.com/rails/sdoc/assets/771968/16aaa8c5-38da-4665-a3cc-78cd4c901e3b) |
| | ![after2b](https://github.com/rails/sdoc/assets/771968/9932aa7e-2c84-49ee-9407-c2a4b3e8bfb3) |
