### PR TITLE
Consolidate `project_version` and `badge_version`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,6 +54,9 @@ class RailsTask < Rails::API::EdgeTask
 
   def setup_horo_variables
     super
+
+    ENV["HORO_BADGE_VERSION"] ||= "edge" if ENV["HORO_PROJECT_VERSION"]&.include?("@")
+
     if ENV['NETLIFY']
       ENV['HORO_CANONICAL_URL'] = ENV.fetch('DEPLOY_PRIME_URL', 'https://edgeapi.rubyonrails.org')
     end

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -22,7 +22,7 @@
         <% if project_name %>
             <div>
                 <%= project_name %>
-                <span title="<%= project_git_head %>"><%= badge_version || project_version %></span>
+                <span title="<%= project_git_head %>"><%= project_version %></span>
             </div>
         <% end %>
 
@@ -40,8 +40,8 @@
             <% end %>
         </h2>
 
-        <% if badge_version %>
-            <div id="version-badge"><%= badge_version %></div>
+        <% if project_version %>
+            <div id="version-badge"><%= project_version %></div>
         <% end %>
     </div>
 

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -19,7 +19,7 @@
         <% if project_name %>
             <div>
                 <%= project_name %>
-                <span title="<%= project_git_head %>"><%= badge_version || project_version %></span>
+                <span title="<%= project_git_head %>"><%= project_version %></span>
             </div>
         <% end %>
 
@@ -36,8 +36,8 @@
             <li>Last modified: <%= file.file_stat.mtime %></li>
         </ul>
 
-        <% if badge_version %>
-            <div id="version-badge"><%= badge_version %></div>
+        <% if project_version %>
+            <div id="version-badge"><%= project_version %></div>
         <% end %>
     </div>
 

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -17,7 +17,7 @@
         <% if project_name %>
             <div>
                 <%= project_name %>
-                <span title="<%= project_git_head %>"><%= badge_version || project_version %></span>
+                <span title="<%= project_git_head %>"><%= project_version %></span>
             </div>
         <% end %>
 
@@ -28,8 +28,8 @@
             <li><%= h index.relative_name %></li>
             <li>Last modified: <%= index.last_modified %></li>
         </ul>
-        <% if badge_version %>
-            <div id="version-badge"><%= badge_version %></div>
+        <% if project_version %>
+            <div id="version-badge"><%= project_version %></div>
         <% end %>
     </div>
 

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -72,7 +72,11 @@ class RDoc::Generator::SDoc
       exit
     end
 
-    options.title = [ENV["HORO_PROJECT_NAME"], ENV["HORO_BADGE_VERSION"], "API documentation"].compact.join(" ")
+    options.title = [
+      ENV["HORO_PROJECT_NAME"],
+      ENV["HORO_BADGE_VERSION"] || ENV["HORO_PROJECT_VERSION"],
+      "API documentation"
+    ].compact.join(" ")
   end
 
   def initialize(store, options)

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -34,11 +34,8 @@ module SDoc::Helpers
   end
 
   def project_version
-    h(ENV["HORO_PROJECT_VERSION"]) if ENV["HORO_PROJECT_VERSION"]
-  end
-
-  def badge_version
-    h(ENV["HORO_BADGE_VERSION"]) if ENV["HORO_BADGE_VERSION"]
+    version = ENV["HORO_BADGE_VERSION"] || ENV["HORO_PROJECT_VERSION"]
+    h version if version
   end
 
   def project_git_head
@@ -50,7 +47,7 @@ module SDoc::Helpers
   end
 
   def og_title(title)
-    project = [project_name, badge_version].join(" ").strip
+    project = [project_name, project_version].join(" ").strip
     "#{h title}#{" (#{project})" unless project.empty?}"
   end
 

--- a/lib/sdoc/postprocessor.rb
+++ b/lib/sdoc/postprocessor.rb
@@ -61,8 +61,8 @@ module SDoc::Postprocessor
     uri = URI(url)
 
     unless uri.path.match?(%r"\A/v\d")
-      if version.match?(/\A[.0-9]+\z/)
-        uri.path = "/v#{version}#{uri.path}"
+      if version.match?(/\Av?[.0-9]+\z/)
+        uri.path = "/#{version.sub(/\Av?/, "v")}#{uri.path}"
       else
         uri.host = "edge#{uri.host}"
       end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -208,23 +208,15 @@ describe SDoc::Helpers do
       end
     end
 
-    it "returns nil when ENV['HORO_PROJECT_VERSION'] is not set" do
-      with_env("HORO_PROJECT_VERSION" => nil) do
+    it "prioritizes ENV['HORO_BADGE_VERSION'] over ENV['HORO_PROJECT_VERSION']" do
+      with_env("HORO_BADGE_VERSION" => "badge", "HORO_PROJECT_VERSION" => "project") do
+        _(@helpers.project_version).must_equal "badge"
+      end
+    end
+
+    it "returns nil when neither ENV['HORO_BADGE_VERSION'] nor ENV['HORO_PROJECT_VERSION'] are set" do
+      with_env("HORO_BADGE_VERSION" => nil, "HORO_PROJECT_VERSION" => nil) do
         _(@helpers.project_version).must_be_nil
-      end
-    end
-  end
-
-  describe "#badge_version" do
-    it "returns escaped version from ENV['HORO_BADGE_VERSION']" do
-      with_env("HORO_BADGE_VERSION" => "~> 1.0.0") do
-        _(@helpers.badge_version).must_equal "~&gt; 1.0.0"
-      end
-    end
-
-    it "returns nil when ENV['HORO_BADGE_VERSION'] is not set" do
-      with_env("HORO_BADGE_VERSION" => nil) do
-        _(@helpers.badge_version).must_be_nil
       end
     end
   end
@@ -265,26 +257,26 @@ describe SDoc::Helpers do
   end
 
   describe "#og_title" do
-    it "includes ENV['HORO_PROJECT_NAME'] and ENV['HORO_BADGE_VERSION']" do
-      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_BADGE_VERSION" => "v2.0") do
+    it "includes ENV['HORO_PROJECT_NAME'] and ENV['HORO_PROJECT_VERSION']" do
+      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_PROJECT_VERSION" => "v2.0") do
         _(@helpers.og_title("Foo")).must_equal "Foo (My Gem v2.0)"
       end
 
-      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_BADGE_VERSION" => nil) do
+      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_PROJECT_VERSION" => nil) do
         _(@helpers.og_title("Foo")).must_equal "Foo (My Gem)"
       end
 
-      with_env("HORO_PROJECT_NAME" => nil, "HORO_BADGE_VERSION" => "v2.0") do
+      with_env("HORO_PROJECT_NAME" => nil, "HORO_PROJECT_VERSION" => "v2.0") do
         _(@helpers.og_title("Foo")).must_equal "Foo (v2.0)"
       end
 
-      with_env("HORO_PROJECT_NAME" => nil, "HORO_BADGE_VERSION" => nil) do
+      with_env("HORO_PROJECT_NAME" => nil, "HORO_PROJECT_VERSION" => nil) do
         _(@helpers.og_title("Foo")).must_equal "Foo"
       end
     end
 
     it "escapes the title" do
-      with_env("HORO_PROJECT_NAME" => "Ruby & Rails", "HORO_BADGE_VERSION" => "~> 1.0.0") do
+      with_env("HORO_PROJECT_NAME" => "Ruby & Rails", "HORO_PROJECT_VERSION" => "~> 1.0.0") do
         _(@helpers.og_title("Foo<Bar>")).must_equal "Foo&lt;Bar&gt; (Ruby &amp; Rails ~&gt; 1.0.0)"
       end
     end

--- a/spec/postprocessor_spec.rb
+++ b/spec/postprocessor_spec.rb
@@ -34,19 +34,16 @@ describe SDoc::Postprocessor do
         <a href="https://guides.rubyonrails.org/testing.html">Testing</a>
       HTML
 
-      with_env("HORO_PROJECT_VERSION" => "3.2.1", "HORO_PROJECT_NAME" => "Ruby on Rails") do
-        _(SDoc::Postprocessor.process(rendered)).
-          must_include %(<a href="https://guides.rubyonrails.org/v3.2.1/testing.html">Testing</a>)
-      end
-
-      with_env("HORO_PROJECT_VERSION" => "main@1337c0d3", "HORO_PROJECT_NAME" => "Ruby on Rails") do
-        _(SDoc::Postprocessor.process(rendered)).
-          must_include %(<a href="https://edgeguides.rubyonrails.org/testing.html">Testing</a>)
-      end
-
-      with_env("HORO_PROJECT_VERSION" => nil, "HORO_PROJECT_NAME" => "Ruby on Rails") do
-        _(SDoc::Postprocessor.process(rendered)).
-          must_include %(<a href="https://guides.rubyonrails.org/testing.html">Testing</a>)
+      {
+        "3.2.1" => %(<a href="https://guides.rubyonrails.org/v3.2.1/testing.html">Testing</a>),
+        "v3.2.1" => %(<a href="https://guides.rubyonrails.org/v3.2.1/testing.html">Testing</a>),
+        "main@1337c0d3" => %(<a href="https://edgeguides.rubyonrails.org/testing.html">Testing</a>),
+        "edge" => %(<a href="https://edgeguides.rubyonrails.org/testing.html">Testing</a>),
+        nil => %(<a href="https://guides.rubyonrails.org/testing.html">Testing</a>),
+      }.each do |version, expected|
+        with_env("HORO_PROJECT_VERSION" => version, "HORO_PROJECT_NAME" => "Ruby on Rails") do
+          _(SDoc::Postprocessor.process(rendered)).must_include expected
+        end
       end
     end
 

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -46,21 +46,27 @@ describe RDoc::Generator::SDoc do
   end
 
   describe "options.title" do
-    it "includes ENV['HORO_PROJECT_NAME'] and ENV['HORO_BADGE_VERSION'] by default" do
-      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_BADGE_VERSION" => "v2.0") do
+    it "includes ENV['HORO_PROJECT_NAME'] and ENV['HORO_PROJECT_VERSION'] by default" do
+      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_PROJECT_VERSION" => "v2.0") do
         _(parse_options().title).must_equal "My Gem v2.0 API documentation"
       end
 
-      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_BADGE_VERSION" => nil) do
+      with_env("HORO_PROJECT_NAME" => "My Gem", "HORO_PROJECT_VERSION" => nil) do
         _(parse_options().title).must_equal "My Gem API documentation"
       end
 
-      with_env("HORO_PROJECT_NAME" => nil, "HORO_BADGE_VERSION" => "v2.0") do
+      with_env("HORO_PROJECT_NAME" => nil, "HORO_PROJECT_VERSION" => "v2.0") do
         _(parse_options().title).must_equal "v2.0 API documentation"
       end
 
-      with_env("HORO_PROJECT_NAME" => nil, "HORO_BADGE_VERSION" => nil) do
+      with_env("HORO_PROJECT_NAME" => nil, "HORO_PROJECT_VERSION" => nil) do
         _(parse_options().title).must_equal "API documentation"
+      end
+    end
+
+    it "prioritizes ENV['HORO_BADGE_VERSION'] over ENV['HORO_PROJECT_VERSION']" do
+      with_env("HORO_BADGE_VERSION" => "badge", "HORO_PROJECT_VERSION" => "project") do
+        _(parse_options().title).must_equal "badge API documentation"
       end
     end
 


### PR DESCRIPTION
Since 5042d1ea95190aea2abd7641af2e525359bf6271, the value of `ENV["HORO_BADGE_VERSION"]` is preferred over the value of `ENV["HORO_PROJECT_VERSION"]`.  Therefore, we can consolidate the `project_version` and `badge_version` helpers.

Note that while `ENV["HORO_BADGE_VERSION"]` has the format we desire, `ENV["HORO_PROJECT_VERSION"]` is the more obvious and preferable name. After these changes is released, we can encourage consumers (namely, Rails) to set `ENV["HORO_PROJECT_VERSION"]` with the same value as `ENV["HORO_BADGE_VERSION"]` and then to drop `ENV["HORO_BADGE_VERSION"]` altogether.
