### PR TITLE
Drop "logo" from logo image alt text

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -4,7 +4,7 @@
 <nav class="panel panel_tree" id="panel" data-turbo-permanent>
   <div class="logo">
     <a href="/">
-      <img width="300" src="/i/logo.svg" alt="Ruby on Rails logo">
+      <img width="300" src="/i/logo.svg" alt="<%= project_name %>">
     </a>
   </div>
   <div class="header">


### PR DESCRIPTION
From https://www.w3.org/WAI/tutorials/images/tips/:

> Usually, there’s no need to include words like “image”, “icon”, or
> “picture” in the alt text. People who can see will know this already,
> and screen readers announce the presence of an image.

And from https://www.a11yproject.com/posts/alt-text/:

> Make sure the description of the image is useful. For example, if the
> image is of a company's logo, the `alt` should be the company's name.
> The word "logo" is not necessary or useful as part of the alternative
> text.

Additionally, this commit uses `project_name` in the alt text instead of hardcoding "Ruby on Rails".
