### PR TITLE
Factor out version badge HTML to `_panel.rhtml`

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -1,4 +1,8 @@
 <a href="#" class="back-to-top"></a>
+<% if project_version %>
+  <div id="version-badge"><%= project_version %></div>
+<% end %>
+
 <input type="checkbox" id="hamburger" class="panel_checkbox">
 <label class="panel_mobile_button" for="hamburger"><span></span> Menu</label>
 <nav class="panel panel_tree" id="panel" data-turbo-permanent>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -39,10 +39,6 @@
                 </span>
             <% end %>
         </h2>
-
-        <% if project_version %>
-            <div id="version-badge"><%= project_version %></div>
-        <% end %>
     </div>
 
     <main id="bodyContent">

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -35,10 +35,6 @@
             </li>
             <li>Last modified: <%= file.file_stat.mtime %></li>
         </ul>
-
-        <% if project_version %>
-            <div id="version-badge"><%= project_version %></div>
-        <% end %>
     </div>
 
     <main id="bodyContent">

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -28,9 +28,6 @@
             <li><%= h index.relative_name %></li>
             <li>Last modified: <%= index.last_modified %></li>
         </ul>
-        <% if project_version %>
-            <div id="version-badge"><%= project_version %></div>
-        <% end %>
     </div>
 
     <main id="bodyContent">


### PR DESCRIPTION
The version badge element uses `position: fixed`, so there is no need to nest it in the banner element.