### PR TITLE
Remove banner from `index.rhtml`

### DIFF
--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -13,23 +13,6 @@
 
     <%= include_template '_panel.rhtml' %>
 
-    <div class="banner">
-        <% if project_name %>
-            <div>
-                <%= project_name %>
-                <span title="<%= project_git_head %>"><%= project_version %></span>
-            </div>
-        <% end %>
-
-        <h2>
-            <%= h index.name %>
-        </h2>
-        <ul class="files">
-            <li><%= h index.relative_name %></li>
-            <li>Last modified: <%= index.last_modified %></li>
-        </ul>
-    </div>
-
     <main id="bodyContent">
         <%= include_template '_context.rhtml', {:context => index } %>
     </main>


### PR DESCRIPTION
The banner on the index page contains superfluous and even misleading information.  The project name should be conveyed by the page title and logo, and the project version should be conveyed by the page title and version badge.  Furthermore, the "Last modified" time is the mtime of the file on disk, unrelated to the time of the last commit for the file or even for the branch as a whole.

This commit removes the banner from the index page for a cleaner appearance.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/e192b42e-c63b-4a2b-a2dd-3ccc392c8eb3) | ![after](https://github.com/rails/sdoc/assets/771968/1d252c3d-f2f7-4ae9-a4aa-1e62da5236a6) |
