### PR TITLE
Remove misleading "Last modified" time from `file.rhtml`

### DIFF
--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -33,7 +33,6 @@
                     <a href="<%= github %>" target="_blank" class="github_url">on GitHub</a>
                 <% end %>
             </li>
-            <li>Last modified: <%= file.file_stat.mtime %></li>
         </ul>
     </div>
 


### PR DESCRIPTION
When seeing "Last modified" time in the context of a version-controlled project, users are likely to think it is the time of the last revision. However, the "Last modified" time is the mtime of the file on disk, unrelated to the time of the last commit for the file or even for the branch as a whole.

Since that information can be misleading and is not particularly useful, this commit removes it.
