### PR TITLE
Add break opportunities in long names for mobile

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -14,7 +14,7 @@
     <div class="sectiontitle">Required Files</div>
     <ul>
       <% context.requires.each do |req| %>
-        <li><%= h req.name %></li>
+        <li><%= full_name req.name %></li>
       <% end %>
     </ul>
   <% end %>
@@ -58,9 +58,9 @@
       <% context.includes.each do |inc| %>
         <li>
           <% if inc.module.is_a?(String) %>
-            <%= h inc.name %>
+            <%= full_name inc.name %>
           <% else %>
-            <%= link_to inc.module.full_name, inc.module %>
+            <%= link_to inc.module %>
           <% end %>
         </li>
       <% end %>
@@ -144,7 +144,7 @@
             <p class="aka">
               Also aliased as:
               <%# Sometimes a parent cannot be determined. See ruby/rdoc@85ebfe13dc. %>
-              <%= method.aliases.map { |aka| link_to aka.name, (aka if aka.parent) }.join(", ") %>.
+              <%= method.aliases.map { |aka| link_to_if aka.parent, aka.name, aka }.join(", ") %>.
             </p>
           <% end %>
 
@@ -191,7 +191,7 @@
       <% (context.modules.sort + context.classes.sort).each do |mod| %>
         <li>
           <span class="type"><%= mod.type.upcase %></span>
-          <%= link_to mod.full_name, mod %>
+          <%= link_to mod %>
         </li>
       <% end %>
     </ul>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -28,14 +28,10 @@
 
         <h2>
             <span class="type"><%= klass.module? ? 'Module' : 'Class' %></span>
-            <%= h klass.full_name %>
-            <% if klass.type == "class" && klass.superclass %>
-                <span class="parent">&lt;
-                    <% if klass.superclass.is_a?(String) %>
-                    <%= klass.superclass %>
-                    <% else %>
-                    <%= link_to klass.superclass.full_name, klass.superclass %>
-                    <% end %>
+            <%= full_name klass %>
+            <% if klass.type == "class" && superclass = klass.superclass %>
+                <span class="parent">
+                    &lt; <%= superclass.is_a?(String) ? full_name(superclass) : link_to(superclass) %>
                 </span>
             <% end %>
         </h2>
@@ -51,7 +47,7 @@
                 <summary class="sectiontitle">Appears in</summary>
                 <ul class="files">
                     <% klass.in_files.each do |file| %>
-                    <li><%= link_to file.absolute_name, file %></li>
+                    <li><%= link_to file %></li>
                     <% end %>
                 </ul>
             </details>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -28,7 +28,7 @@
         </h2>
         <ul class="files">
             <li>
-                <%= h file.relative_name %>
+                <%= full_name file %>
                 <% if github = github_url(file.relative_name) %>
                     <a href="<%= github %>" target="_blank" class="github_url">on GitHub</a>
                 <% end %>


### PR DESCRIPTION
When wrapping text, Safari and Chrome do not consider `/` nor `:` as word break characters.  Firefox considers `/` as a word break character but not `:`.  This can lead to horizontal overflow issues with long file paths and module names on mobile.

This commit adds a `full_name` helper to insert word-break opportunities into file paths and module names.  It also revises the `link_to` helper to do the same when given an `RDoc::CodeObject`.  The helpers insert `<wbr>` tags which tell the browser that the text can be wrapped at that point.

| Before | (Before) | After |
| --- | --- | --- |
| ![before1a](https://github.com/rails/sdoc/assets/771968/c0cad66c-06a3-4731-839b-4bc99782de41) | ![before1b](https://github.com/rails/sdoc/assets/771968/59fdf51b-25f8-4d1c-8e3e-638496ca4d2d) | ![after1](https://github.com/rails/sdoc/assets/771968/5cba9b60-759d-493e-88d0-96a554e24161) |
| ![before2a](https://github.com/rails/sdoc/assets/771968/21819165-0177-4d88-817f-ac1636023767) | ![before2b](https://github.com/rails/sdoc/assets/771968/f053c27e-76a4-4518-9d63-b47330046ff2) | ![after2](https://github.com/rails/sdoc/assets/771968/bf7ac626-41a5-4035-a7ee-a05031269b59) |

(The above screenshots were taken using Chrome's developer tools on desktop.  The "Before" screenshots may vary between different browsers.)