### PR TITLE
Unsticky "Appears in" element from bottom of page

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -10,8 +10,6 @@ body {
   line-height: 1.25em;
   min-height: 100%;
   display: grid;
-  grid-template-rows: min-content min-content auto min-content;
-  grid-template-columns: 300px auto;
 
   --link-color: #CC0000;
   --link-hover-color: #990000;
@@ -19,41 +17,41 @@ body {
 }
 
 body {
-  grid-template-rows: min-content min-content auto min-content;
+  grid-template-rows: min-content min-content min-content;
   grid-template-columns: 100%;
 }
 
 @media (min-width: 600px) {
   body {
-    grid-template-rows: min-content min-content auto min-content;
+    grid-template-rows: min-content min-content min-content;
     grid-template-columns: 300px auto;
   }
 
   nav {
     grid-row-start: 1;
-    grid-row-end: 4;
+    grid-row-end: 3;
     grid-column-start: 1;
     grid-column-end: 1;
   }
 
   div.banner {
-    grid-row-start: 2;
-    grid-row-end: 2;
+    grid-row-start: 1;
+    grid-row-end: 1;
     grid-column-start: 2;
     grid-column-end: 2;
   }
 
   #bodyContent {
-    grid-row-start: 3;
-    grid-row-end: 3;
+    grid-row-start: 2;
+    grid-row-end: 2;
     grid-column-start: 2;
     grid-column-end: 2;
     min-width: 0;
   }
 
   footer {
-    grid-row-start: 4;
-    grid-row-end: 4;
+    grid-row-start: 3;
+    grid-row-end: 3;
     grid-column-start: 2;
     grid-column-end: 2;
   }


### PR DESCRIPTION
Stickying the "Appears in" `<details>` at the bottom of the page causes the element to jump up when it is expanded, which is unexpected and unusual.  Since the element already hides information by default, there is no need to force it to stay all the way at the bottom of the page. This commit removes the sticky positioning and fixes some inconsistencies in the grid definition.

| Before | After |
| --- | --- |
| ![before1](https://github.com/rails/sdoc/assets/771968/3f1279d4-bb5f-4579-802a-561aa2e76633) | ![after1](https://github.com/rails/sdoc/assets/771968/bb00e575-a6ab-4143-8c88-ed6d1d0783e9) |
| ![before2](https://github.com/rails/sdoc/assets/771968/9b2fd79f-3906-466e-98a8-419d7f101174) | ![after2](https://github.com/rails/sdoc/assets/771968/2d195807-b621-4c68-a907-06189da74b53) |
