### PR TITLE
Fix Minitest deprecation warning

### DIFF
--- a/spec/rdoc_generator_markup_spec.rb
+++ b/spec/rdoc_generator_markup_spec.rb
@@ -18,7 +18,7 @@ describe RDoc::Generator::Markup do
 
     it "should ignore lower level titles" do
       @module.comment = RDoc::Comment.new '== Some Title'
-      _(@module.comment_title).must_equal nil
+      _(@module.comment_title).must_be_nil
     end
   end
 


### PR DESCRIPTION
This fixes the following deprecation warning when running `rake test`:

> DEPRECATED: Use assert_nil if expecting nil from .../sdoc/spec/rdoc_generator_markup_spec.rb:21. This will fail in Minitest 6.