### PR TITLE
Fix file list in Safari

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -468,7 +468,14 @@ details.more-less summary:hover {
   color: inherit;
 }
 
-details.more-less summary::marker {
+details.more-less summary {
+  list-style-type: none;
+}
+details.more-less summary::-webkit-details-marker {
+  display: none;
+}
+
+details.more-less summary::before {
   font-size: 1.15em;
   content: "+";
 }
@@ -477,7 +484,7 @@ details.more-less[open] summary {
   top: calc(100% + 0.5em);
 }
 
-details.more-less[open] summary::marker {
+details.more-less[open] summary::before {
   content: "-";
 }
 


### PR DESCRIPTION
Safari does not support the `::marker` psuedo-element.  It does support a `::-webkit-details-marker` psuedo-element, but that element's `content` cannot be set.  Therefore, to achieve the desired appearance in Safari (as well as other browsers), this commit hides the summary marker and uses `summary::before` to render the `+` and `-` icons.