### PR TITLE
Fix choice of main page

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,13 +43,14 @@ class RailsTask < Rails::API::EdgeTask
     "doc/rails"
   end
 
+  # This file has been renamed in Rails 7.1.
+  # TODO: Remove this override some time after Rails 7.1 is released.
   def api_main
-    "rails/railties/RDOC_MAIN.md"
+    super.sub("RDOC_MAIN.rdoc", "RDOC_MAIN.md")
   end
 
   def component_root_dir(component)
-    path = File.join("rails", component)
-    return path
+    File.join("rails", component)
   end
 
   def setup_horo_variables

--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -87,6 +87,7 @@ class RDoc::Generator::SDoc
     end
     @options.pipe = true
 
+    @original_dir = Pathname.pwd
     @template_dir = Pathname.new(options.template_dir)
     @base_dir = options.root
 
@@ -117,6 +118,14 @@ class RDoc::Generator::SDoc
 
   def file_dir
     FILE_DIR
+  end
+
+  ### Determines index page based on @options.main_page (or lack thereof)
+  def index
+    path = @original_dir.join(@options.main_page || @options.files.first || "")
+    file = @files.find { |file| @options.root.join(file.full_name) == path }
+    raise "Could not find main page #{path.to_s.inspect} among rendered files" if !file
+    file
   end
 
   protected
@@ -200,25 +209,6 @@ class RDoc::Generator::SDoc
       tree << item
     end
     tree
-  end
-
-  ### Determines index page based on @options.main_page (or lack thereof)
-  def index
-    # Break early to avoid a big if block when no main page is specified
-    default = @files.first
-    return default unless @options.main_page
-
-    # TODO: Total hack to strip the source directory from the main page
-    # Since the file list does not include the root source path
-    clean_main = @options.main_page.gsub("rails/", "")
-
-    if file = @files.find { |f| f.full_name == clean_main }
-      debug_msg "Found main at #{file}"
-      file
-    else
-      debug_msg "Falling back to default main at #{default}"
-      default
-    end
   end
 
   ### Copy all the resource files to output dir

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,13 +12,17 @@ ensure
   ENV.replace(original_env)
 end
 
+def rdoc_dry_run(*options)
+  RDoc::RDoc.new.tap do |rdoc|
+    rdoc.document(%W[--dry-run --quiet --format=sdoc --template=rails] + options.flatten)
+  end
+end
+
 # Returns an RDoc::TopLevel instance for the given Ruby code.
 def rdoc_top_level_for(ruby_code)
   # RDoc has a lot of internal state that needs to be initialized. The most
   # foolproof way to initialize it is by simply running it with a dummy file.
-  $rdoc_for_specs ||= RDoc::RDoc.new.tap do |rdoc|
-    rdoc.document(%W[--dry-run --quiet --format=sdoc --template=rails --files #{__FILE__}])
-  end
+  $rdoc_for_specs ||= rdoc_dry_run("--files", __FILE__)
 
   $rdoc_for_specs.store = RDoc::Store.new
 


### PR DESCRIPTION
Prior to this commit, `RDoc::Generator::SDoc#index` exhibited the following incorrect behaviors:

1. When `--main` was not specified, `index` would choose the alphabetically-first file as the main page, instead of the first file in the list of files.

2. When `--main` was specified but was prefixed with `--root`, and `--root` did not start with "rails/", `index` would choose the alphabetically-first file.  (Such as when `--root` was an absolute path, or a deeply nested relative path, or simply a path for a non-Rails project.)

3. When `--main` was specified but was not in the list of files, `index` would choose the alphabetically-first file.

This commit fixes `RDoc::Generator::SDoc#index` such that it:

1. Chooses the first file in the list of files as the default main page.

2. Handles any kind of `--main` path.

3. Raises an error when `--main` isn't among the rendered files.