### PR TITLE
Render breadcrumb links for module's parents

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -21,7 +21,7 @@
     <main id="content">
         <div class="content__full-name">
           <span class="qualifier"><%= klass.type %></span>
-          <%= full_name klass %>
+          <%= module_breadcrumbs klass %>
           <% if !klass.module? && superclass = klass.superclass %>
             <span class="qualifier">&lt;</span>
             <%= superclass.is_a?(String) ? full_name(superclass) : link_to(superclass) %>

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -55,6 +55,9 @@ a {
 a:has(> code:only-child) {
   text-decoration: none;
 }
+code a {
+  text-decoration: none;
+}
 
 /* TODO: Remove this hack when Firefox supports `:has()` */
 a code {

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -116,6 +116,17 @@ module SDoc::Helpers
     end
   end
 
+  def module_breadcrumbs(rdoc_module)
+    crumbs = [h(rdoc_module.name)]
+
+    rdoc_module.each_parent do |parent|
+      break if parent.is_a?(RDoc::TopLevel)
+      crumbs.unshift(link_to(h(parent.name), parent))
+    end
+
+    "<code>#{crumbs.join("::<wbr>")}</code>"
+  end
+
   def method_signature(rdoc_method)
     if rdoc_method.call_seq
       rdoc_method.call_seq.split(/\n+/).map do |line|

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -502,6 +502,27 @@ describe SDoc::Helpers do
     end
   end
 
+  describe "#module_breadcrumbs" do
+    it "renders links for each of the module's parents" do
+      top_level = rdoc_top_level_for <<~RUBY
+        module Foo; module Bar; module Qux; end; end; end
+      RUBY
+
+      foo = top_level.find_module_named("Foo")
+      bar = top_level.find_module_named("Foo::Bar")
+      qux = top_level.find_module_named("Foo::Bar::Qux")
+
+      _(@helpers.module_breadcrumbs(foo)).
+        must_equal "<code>Foo</code>"
+
+      _(@helpers.module_breadcrumbs(bar)).
+        must_equal "<code>#{@helpers.link_to "Foo", foo}::<wbr>Bar</code>"
+
+      _(@helpers.module_breadcrumbs(qux)).
+        must_equal "<code>#{@helpers.link_to "Foo", foo}::<wbr>#{@helpers.link_to "Bar", bar}::<wbr>Qux</code>"
+    end
+  end
+
   describe "#method_signature" do
     it "returns the method signature wrapped in <code>" do
       method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo").find_method("bar", false)


### PR DESCRIPTION
This converts the name displayed at the top of each module's page into breadcrumb links.  Each part of the name now links to the corresponding parent module's page.

Closes #212.

---

__Before__

![before](https://github.com/rails/sdoc/assets/771968/96decceb-c469-4dcf-b4a2-894261c2a755)

__After__

![after](https://github.com/rails/sdoc/assets/771968/0454c91c-6de9-4bb5-a269-031570c46471)

