### PR TITLE
Contain more-less `<summary>` inside `<details>`

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -599,19 +599,22 @@ html {
  */
 
 details.more-less {
-  margin-top: var(--space-sm);
+  margin-top: 0;
+  padding-bottom: calc(var(--line-height) * 1em + var(--space-sm));
   position: relative;
 }
 
 details.more-less > ul {
-  margin-top: 0;
+  margin-top: var(--space-sm);
 }
 
 details.more-less summary {
   position: absolute;
-  padding-left: 0.25em;
+  bottom: 0;
+
   font-weight: bold;
   color: var(--icon-color);
+  padding-left: 0.25em;
 }
 
 @media (hover: hover) {
@@ -629,12 +632,7 @@ details.more-less summary::-webkit-details-marker {
 }
 
 details.more-less summary::before {
-  font-size: 1.15em;
   content: "+";
-}
-
-details.more-less[open] summary {
-  top: calc(100% + var(--space-sm));
 }
 
 details.more-less[open] summary::before {


### PR DESCRIPTION
Prior to this commit, the `<summary>` element of a more-less list was positioned just below the bottom of the `<details>` element, which caused it overlap with any subsequent padding or margin.

This commit extends the `<details>` element by adding bottom padding, and aligns the bottom of the `<summary>` element with the bottom of the `<details>` element so that the `<summary>` is always contained within the block.

| Before | After |
| --- | --- |
| ![before1](https://github.com/rails/sdoc/assets/771968/aa35ab41-9530-4148-bd1e-1073845710ef) | ![after1](https://github.com/rails/sdoc/assets/771968/6c0a7139-e1f3-4ee6-82f3-77e15d433966) |
| ![before2](https://github.com/rails/sdoc/assets/771968/1c84d432-4b52-4297-911f-1908e2ea640a) | ![after2](https://github.com/rails/sdoc/assets/771968/f46c2c5d-d716-4e9a-b0be-cdfc301dc1e4) |
