### PR TITLE
Increase top margin for long list items

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -382,6 +382,11 @@ html {
   margin-top: var(--space-sm);
 }
 
+/* Increase top margin for list items when any item has more than one paragraph */
+:where(#content :is(ol, ul):has(> li > p:not(:only-child))) * + li {
+  margin-top: var(--space);
+}
+
 :where(#content) code {
   font-style: normal;
 }


### PR DESCRIPTION
List items inside `#content` use `var(--space-sm)` as their top margin because `var(--space)` looks too disjointed for single-paragraph items, especially single-line items.  However, when a list item contains an element that itself has a `var(--space)` top margin, the list item's top margin looks mismatched.

This commit adds a style tweak such that all list items in a list with any multi-paragraph items will use `var(--space)` for their top margin. (More specifically, when any item contains a paragraph plus another block level element, such as another paragraph or a code block.)

Unfortunately, this enhancement does not currently work in Firefox because it relies on the `:has()` selector.  However, it is only a minor enhancement, and Firefox plans to support `:has()` in the near future.

| Before | After |
| --- | --- |
| ![before1](https://github.com/rails/sdoc/assets/771968/364ab7cb-14c5-471b-882c-a0ec3f8510c0) | ![after1](https://github.com/rails/sdoc/assets/771968/9b0e3f5e-4fe9-47b3-a250-5eb6554d6c02) |
| ![before2-after2](https://github.com/rails/sdoc/assets/771968/9052d625-28df-4970-975b-7ff5fe08c956) | ![before2-after2](https://github.com/rails/sdoc/assets/771968/9052d625-28df-4970-975b-7ff5fe08c956) **(same)** |
