### PR TITLE
Reduce padding of code blocks

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -518,8 +518,8 @@ html {
 
 .method__source pre,
 .description pre {
-  padding: 0.5em 1em;
-  border-radius: 8px;
+  padding: 0.5ch 1ch;
+  border-radius: 4px;
   overflow-x: auto;
 }
 


### PR DESCRIPTION
This style tweak reduces the padding of code blocks to make the code feel less disconnected from the surrounding prose.  (Note that, effectively, `em` is character height whereas `ch` is character width.)

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/35a30689-ab19-4f03-9a63-8a452cc69fc8) | ![after](https://github.com/rails/sdoc/assets/771968/a3a5d281-738d-42b9-829c-185ba369e081) |
