### PR TITLE
Remove keyboard shortcuts that use meta keys

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -28,10 +28,6 @@ Searchdoc.Navigation = new function() {
             case 38: //Event.KEY_UP:
             case 39: //Event.KEY_RIGHT:
             case 40: //Event.KEY_DOWN:
-            case 73: // i - qwerty
-            case 74: // j
-            case 75: // k
-            case 76: // l
                 this.clearMoveTimeout();
                 break;
         }
@@ -42,36 +38,22 @@ Searchdoc.Navigation = new function() {
 
         switch (e.keyCode) {
             case 37: //Event.KEY_LEFT:
-            case 74: // j (qwerty)
                 if (this.moveLeft()) e.preventDefault();
                 break;
             case 38: //Event.KEY_UP:
-            case 73: // i (qwerty)
-                if (e.keyCode == 38 || e.ctrlKey) {
-                    if (this.moveUp()) e.preventDefault();
-                    this.startMoveTimeout(false);
-                }
+                if (this.moveUp()) e.preventDefault();
+                this.startMoveTimeout(false);
                 break;
             case 39: //Event.KEY_RIGHT:
-            case 76: // l (qwerty)
                 if (this.moveRight()) e.preventDefault();
                 break;
             case 40: //Event.KEY_DOWN:
-            case 75: // k (qwerty)
-                if (e.keyCode == 40 || e.ctrlKey) {
-                    if (this.moveDown()) e.preventDefault();
-                    this.startMoveTimeout(true);
-                }
+                if (this.moveDown()) e.preventDefault();
+                this.startMoveTimeout(true);
                 break;
             case 13: //Event.KEY_RETURN:
                 if(e.target.dataset["turbo"]) { break; }
                 if (this.$current) this.select(this.$current);
-                break;
-            case 83: // s (qwerty) - Focuses search
-                if (e.ctrlKey) {
-                    $('#search').focus();
-                    e.preventDefault();
-                }
                 break;
             case 191: // / - Search by pressing "/"
                 if( !$('#search').is(":focus") ) {
@@ -80,7 +62,6 @@ Searchdoc.Navigation = new function() {
                 }
                 break;
         }
-        if (e.ctrlKey && e.shiftKey) this.select(this.$current);
     };
 
     this.clearMoveTimeout = function() {


### PR DESCRIPTION
These shortcuts interfere with the browser's own keyboard shortcuts such as <kbd>Ctrl + Shift + I</kbd> to open the developer console.