### PR TITLE
Remove version badge

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -1,7 +1,4 @@
 <a href="#" class="back-to-top"></a>
-<% if project_version %>
-  <div id="version-badge"><%= project_version %></div>
-<% end %>
 
 <nav id="panel" class="panel">
   <div class="banner">

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -177,24 +177,6 @@ th
   font-size: 2rem;
 }
 
-#version-badge {
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 100;
-  color: white;
-  transform: rotate(45deg) translate(27.5%, -40%);
-  min-width: 200px;
-  font-size: 30px;
-  font-weight: bold;
-  font-style: italic;
-  line-height: 1.5;
-  text-shadow: 2px 2px 4px #5400007d;
-  text-align: center;
-  box-shadow: 0px 2px 2px 1px #1209096e;
-  background: radial-gradient(circle, rgb(255, 10, 0) 0%, rgb(200, 0, 0) 90%);
-}
-
 a.back-to-top {
   visibility: hidden;
   position: fixed;


### PR DESCRIPTION
The version badge sometimes hides content, especially on mobile.  Since c17deffa99a415ca43f23a3df61b567aacd237dc, we display a user-friendly version number in the top left corner of the screen at all times.  As such, there isn't a need to also display the same information in the top right corner of the screen.

| Before | After | Before (mobile) | After (mobile) |
| --- | --- | --- | --- |
| <img src="https://github.com/rails/sdoc/assets/771968/5265d605-fe5e-481d-a358-a33f8efec2dd" width="215" alt="before"> | <img src="https://github.com/rails/sdoc/assets/771968/4a897151-2666-4a29-89fa-1302fe22f1bd" width="215" alt="after"> | <img src="https://github.com/rails/sdoc/assets/771968/11a7e32c-4d26-442b-a6d5-5b3ffea7393e" height="120" alt="mbefore"> | <img src="https://github.com/rails/sdoc/assets/771968/be581d10-c352-47e4-97aa-f542d5d7ea44" height="120" alt="mafter"> |
