### PR TITLE
Remove deprecated `charset` attributes

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -4,13 +4,13 @@
 <link rel="stylesheet" href="/css/main.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="/css/highlight.css" type="text/css" media="screen" />
 
-<script src="/js/jquery-3.5.1.min.js" type="text/javascript" charset="utf-8"></script>
-<script src="/js/main.js" type="text/javascript" charset="utf-8"></script>
-<script src="/js/@hotwired--turbo.js" type="text/javascript" charset="utf-8"></script>
-<script src="/js/search_index.js" type="text/javascript" charset="utf-8"></script>
-<script src="/js/searcher.js" type="text/javascript" charset="utf-8"></script>
-<script src="/panel/tree.js" type="text/javascript" charset="utf-8"></script>
-<script src="/js/searchdoc.js" type="text/javascript" charset="utf-8"></script>
+<script src="/js/jquery-3.5.1.min.js" type="text/javascript"></script>
+<script src="/js/main.js" type="text/javascript"></script>
+<script src="/js/@hotwired--turbo.js" type="text/javascript"></script>
+<script src="/js/search_index.js" type="text/javascript"></script>
+<script src="/js/searcher.js" type="text/javascript"></script>
+<script src="/panel/tree.js" type="text/javascript"></script>
+<script src="/js/searchdoc.js" type="text/javascript"></script>
 <meta name="data-tree-keys" content='<%= tree_keys %>'>
 
 <% if canonical = canonical_url(context) %>


### PR DESCRIPTION
Via [MDN][]:

> If present, [the attribute's] value must be an ASCII case-insensitive match for "utf-8". It's unnecessary to specify the charset attribute, because documents must use UTF-8, and the script element inherits its character encoding from the document.

[MDN]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#deprecated_attributes