### PR TITLE
Support unresolved file paths for main page

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -115,7 +115,7 @@ class RDoc::Generator::SDoc
   ### Determines index page based on @options.main_page (or lack thereof)
   def index
     @index ||= begin
-      path = @original_dir.join(@options.main_page || @options.files.first || "")
+      path = @original_dir.join(@options.main_page || @options.files.first || "").expand_path
       file = @files.find { |file| @options.root.join(file.full_name) == path }
       raise "Could not find main page #{path.to_s.inspect} among rendered files" if !file
 

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -118,6 +118,14 @@ describe RDoc::Generator::SDoc do
       end
     end
 
+    it "works with unresolved paths" do
+      Dir.chdir(@dir) do
+        @files.map! { |file| File.join("..", File.basename(@dir), ".", file) }
+        sdoc = rdoc_dry_run("--main", @files.first, "--files", *@files).generator
+        _(sdoc.index.absolute_name).must_equal @files.first
+      end
+    end
+
     it "works with absolute paths" do
       @files.map! { |file| File.join(@dir, file) }
       sdoc = rdoc_dry_run("--main", @files.first, "--files", *@files).generator


### PR DESCRIPTION
This commit allows `RDoc::Generator::SDoc#index` to resolve the main page when the `--main` or `--files` options specify unresolved file paths such as `sibling/../actual/file.md`.