### PR TITLE
Use `@options.dry_run` in `render_template`

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -139,7 +139,7 @@ class RDoc::Generator::SDoc
     templatefile = @template_dir + 'index.rhtml'
     outfile      = @outputdir + 'index.html'
 
-    self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
+    render_template(templatefile, binding, outfile)
   end
 
   ### Generate a documentation file for each class
@@ -152,7 +152,7 @@ class RDoc::Generator::SDoc
       outfile     = @outputdir + klass.path
 
       debug_msg "  rendering #{outfile}"
-      self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
+      render_template(templatefile, binding, outfile)
     end
   end
 
@@ -166,7 +166,7 @@ class RDoc::Generator::SDoc
       debug_msg "  working on %s (%s)" % [ file.full_name, outfile ]
 
       debug_msg "  rendering #{outfile}"
-      self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
+      render_template(templatefile, binding, outfile)
     end
   end
 
@@ -176,7 +176,7 @@ class RDoc::Generator::SDoc
     templatefile = @template_dir + 'file_links.rhtml'
     outfile      = @outputdir + 'panel/file_links.html'
 
-    self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
+    render_template(templatefile, binding, outfile)
   end
 
   ### Create class tree structure and write it as json

--- a/lib/sdoc/templatable.rb
+++ b/lib/sdoc/templatable.rb
@@ -32,17 +32,10 @@ module SDoc::Templatable
   ### Load and render the erb template in the given +templatefile+ within the
   ### specified +context+ (a Binding object) and write it out to +outfile+.
   ### Both +templatefile+ and +outfile+ should be Pathname-like objects.
-  def render_template( templatefile, context, outfile )
+  def render_template(templatefile, context, outfile)
+    return if @options.dry_run
     output = SDoc::Postprocessor.process(eval_template(templatefile, context))
-
-    unless $dryrun
-      outfile.dirname.mkpath
-      outfile.open( 'w', 0644 ) do |file|
-        file.print( output )
-      end
-    else
-      debug_msg "  would have written %d bytes to %s" %
-      [ output.length, outfile ]
-    end
+    outfile.dirname.mkpath
+    outfile.write(output)
   end
 end

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -31,6 +31,19 @@ describe RDoc::Generator::SDoc do
     _(`./bin/sdoc -v`.strip).must_equal SDoc::VERSION
   end
 
+  describe "options.dry_run" do
+    it "prevents files from being rendered" do
+      Dir.mktmpdir do |dir|
+        rdoc_dry_run(
+          "--files", "#{__dir__}/../README.md", "#{__dir__}/../lib/sdoc/version.rb",
+          "--output", dir
+        )
+
+        _(Dir.glob("**/*", base: dir)).must_be_empty
+      end
+    end
+  end
+
   describe "options.github" do
     it "is disabled by default" do
       _(parse_options().github).must_be_nil


### PR DESCRIPTION
The `$dryrun` global variable in `SDoc::Templatable#render_template` is defunct and causes "warning: global variable `$dryrun` not initialized" to be printed when warnings are enabled.

This commit replaces `$dryrun` with `@options.dry_run`.