### PR TITLE
Add description `meta` tag for prose files

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -18,3 +18,6 @@
 <% end %>
 <meta property="og:type" content="article">
 <meta property="article:modified_time" content="<%= og_modified_time %>">
+<% if description = page_description(context.description) %>
+<meta name="description" property="og:description" content="<%= description %>">
+<% end %>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -7,9 +7,6 @@
     <%= include_template '_head.rhtml', {:context => klass, :tree_keys => klass.full_name.split('::') } %>
 
     <meta property="og:title" value="<%= og_title klass.full_name %>">
-    <% if description = page_description(klass.description) %>
-    <meta name="description" property="og:description" content="<%= description %>">
-    <% end %>
 </head>
 
 <body>


### PR DESCRIPTION
This adds a `<meta name="description">` tag for the main page and for other prose files such as README files.  The tags are generated in the same way as for code files.