### PR TITLE
Extract page description after any leading headings

### DIFF
--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -2,6 +2,9 @@ module SDoc::Helpers
   require_relative "helpers/git"
   include SDoc::Helpers::Git
 
+  LEADING_PARAGRAPH_XPATH =
+    "./*[not(self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6)][1][self::p]"
+
   def link_to(text, url = nil, html_attributes = {})
     url, html_attributes = nil, url if url.is_a?(Hash)
     url ||= text
@@ -79,7 +82,7 @@ module SDoc::Helpers
   def page_description(leading_html, max_length: 160)
     return if leading_html.nil? || !leading_html.include?("</p>")
 
-    text = Nokogiri::HTML.fragment(leading_html).at_css("h1 + p, p:first-child")&.inner_text
+    text = Nokogiri::HTML.fragment(leading_html).at(LEADING_PARAGRAPH_XPATH)&.inner_text
     return unless text
 
     if text.length > max_length

--- a/lib/sdoc/search_index.rb
+++ b/lib/sdoc/search_index.rb
@@ -1,5 +1,6 @@
 require "base64"
 require "nokogiri"
+require_relative "helpers"
 
 module SDoc::SearchIndex
   extend self
@@ -120,7 +121,7 @@ module SDoc::SearchIndex
 
   def truncate_description(description, limit)
     return if description.empty?
-    leading_paragraph = Nokogiri::HTML.fragment(description).at_css("h1 + p, p:first-child")
+    leading_paragraph = Nokogiri::HTML.fragment(description).at(SDoc::Helpers::LEADING_PARAGRAPH_XPATH)
     return unless leading_paragraph
 
     # Treat <code> elements as a whole when truncating

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -412,11 +412,21 @@ describe SDoc::Helpers do
         <h1>headline</h1>
         <p>paragraph</p>
       HTML
+
+      _(@helpers.page_description(<<~HTML)).must_equal "paragraph"
+        <h1>1</h1><h2>2</h2><h3>3</h3><h4>4</h4><h5>5</h5><h6>6</h6>
+        <p>paragraph</p>
+      HTML
     end
 
     it "returns nil when there is no leading paragraph" do
       _(@helpers.page_description(<<~HTML)).must_be_nil
         <pre><code>code</code></pre>
+        <p>other</p>
+      HTML
+
+      _(@helpers.page_description(<<~HTML)).must_be_nil
+        <ul><li><p>item</p></li></ul>
         <p>other</p>
       HTML
 


### PR DESCRIPTION
The `page_description` helper extracts the description from the leading paragraph of its input.  Prior to this commit, a paragraph following an `<h1>` was recognized as a leading paragraph, but a paragraph following any other heading was not.

This commit changes `page_description` such that it selects the `<p>` that is the first non-heading element of its input.
