### PR TITLE
Horizontally sticky banner on mobile

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -424,6 +424,7 @@ html {
 
 #content {
   padding: 1em;
+  overflow-x: auto;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
Prior to this commit, when the `#content` element had horizontal overflow on mobile, the `<body>` element would become horizontally scrollable, and the banner would scroll off screen when scrolling.

This commit adds `overflow-x: auto` to `#content` so that horizontal scrolling is limited to the `#content` element and the banner remains fixed in place when scrolling.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/e08c59eb-af8d-426f-af0e-a226465efb52) | ![after](https://github.com/rails/sdoc/assets/771968/c7dda4c3-c75e-4abc-8086-6cf9b899d645) |
