### PR TITLE
Conserve <h1> headings in prose files

### DIFF
--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -16,12 +16,14 @@
     <%= include_template '_panel.rhtml' %>
 
     <main id="content">
-        <hgroup class="content__title">
-          <h1><span class="kind">File</span> <%= full_name file %></h1>
-        </hgroup>
+        <div class="content__title">
+          <%= "<h1>" if file.comment.empty? %>
+            <%= full_name file %>
+          <%= "</h1>" if file.comment.empty? %>
+        </div>
 
         <% if source_url = github_url(file.relative_name) %>
-          <p><%= link_to_external "View on GitHub", source_url %></p>
+          <p class="content__source-link"><%= link_to_external "View on GitHub", source_url %></p>
         <% end %>
 
         <%= include_template '_context.rhtml', {:context => file} %>

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -461,12 +461,13 @@ html {
   font-style: normal;
 }
 
-.content__title :is(h1, p) {
+.content__title {
   font-size: 1.6em;
   line-height: 1.25;
 }
 
 .content__title h1 {
+  font-size: inherit;
   font-weight: normal;
 
   margin-left: 1em;
@@ -477,6 +478,10 @@ html {
   font-style: italic;
 
   margin-top: 0;
+}
+
+.content__source-link {
+  margin-top: var(--space-sm);
 }
 
 .content__section-title {
@@ -598,7 +603,7 @@ html {
  * Description of method or module
  */
 
-#context > .description {
+.content__title ~ #context > .description {
   margin-top: var(--space-lg);
 }
 


### PR DESCRIPTION
For prose files, such as `README` files, it is reasonable to assume that the file content includes an `<h1>` heading, and that the file name is mostly irrelevant.  For example, the file `railties/README.rdoc` includes the heading "Railties -- Gluing the Engine to the Rails".

This commit removes the `<h1>` for a prose file's name, and preserves the file's original `<h1>` instead of making it a subheading of an `<hgroup>` as is done for module descriptions.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/5334c5dc-b511-4bf0-b137-3df97751ed7f) | ![after](https://github.com/rails/sdoc/assets/771968/b4d9248b-2708-4114-a86d-3a945b4dc099) |
