### PR TITLE
Add webrick to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rack"
 gem "rake"
 gem "hoe"
 gem "minitest"
+gem "webrick"
 
 if ENV["rdoc"] == "master"
   gem "rdoc", :github => "ruby/rdoc"


### PR DESCRIPTION
Because webrick was removed from ruby 3.x, running `rackup config.ru` raises `Couldn't find handler for: puma, thin, falcon, webrick. (LoadError)` error.