### PR TITLE
Make method name font-weight bold

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -534,6 +534,10 @@ html {
   white-space: pre-wrap;
 }
 
+.method__name {
+  font-weight: bold;
+}
+
 .method__permalink {
   margin: 0 0 0 0.5em;
 }

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -148,7 +148,7 @@ module SDoc::Helpers
         line.split(" -> ").map { |side| "<code>#{h side}</code>" }.join(" &rarr; ")
       end.join("\n")
     else
-      "<code>#{h rdoc_method.name}#{h rdoc_method.params}</code>"
+      %Q(<code><span class="method__name">#{h rdoc_method.name}</span>#{h rdoc_method.params}</code>)
     end
   end
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -593,7 +593,8 @@ describe SDoc::Helpers do
         module Foo; def bar(qux); end; end
       RUBY
 
-      _(@helpers.method_signature(method)).must_equal "<code>bar(qux)</code>"
+      _(@helpers.method_signature(method)).
+        must_equal %(<code><span class="method__name">bar</span>(qux)</code>)
     end
 
     it "escapes the method signature" do
@@ -601,7 +602,8 @@ describe SDoc::Helpers do
         module Foo; def bar(op = :<, &block); end; end
       RUBY
 
-      _(@helpers.method_signature(method)).must_equal "<code>bar(op = :&lt;, &amp;block)</code>"
+      _(@helpers.method_signature(method)).
+        must_equal %(<code><span class="method__name">bar</span>(op = :&lt;, &amp;block)</code>)
     end
 
     it "handles :call-seq: documentation" do


### PR DESCRIPTION
I think it is easier to read. SDoc v2.6.1 displays method name in bold. Python doc too https://docs.python.org/3/library/smtplib.html.

### main

![main](https://github.com/rails/sdoc/assets/99586/9a43069d-6653-4177-b59b-d568e3127581)

### This PR

![bold](https://github.com/rails/sdoc/assets/99586/a6717b32-2001-4d12-9f77-60565a37b88e)
