### PR TITLE
Increase text contrast for dark mode

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -26,11 +26,11 @@ body {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --text-color: #ddd;
+    --text-color: #dddddd;
     --link-color: #ee3f3f;
 
-    --body-bg: #222222;
-    --code-bg: #000000;
+    --body-bg: #0c0c0c;
+    --code-bg: #1b1b1b;
     --source-code-bg: #000000;
   }
 }

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -69,7 +69,6 @@ a code {
 
 .kind {
   font-family: monospace;
-  font-weight: bold;
 }
 
 .kind::after {

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -520,7 +520,6 @@ html {
 }
 
 .method__signature {
-  font-size: 1.1em;
   padding-bottom: var(--space-sm);
   border-bottom: 2px solid var(--code-bg);
 
@@ -529,7 +528,7 @@ html {
 }
 
 .method__signature h3 {
-  font-size: 1em;
+  font-size: 1rem;
   font-weight: normal;
   white-space: pre-wrap;
 }

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -143,12 +143,12 @@ module SDoc::Helpers
 
   def method_signature(rdoc_method)
     if rdoc_method.call_seq
-      rdoc_method.call_seq.split(/\n+/).map do |line|
-        # Support specifying a call-seq like `to_s -> string`
-        line.split(" -> ").map { |side| "<code>#{h side}</code>" }.join(" &rarr; ")
-      end.join("\n")
+      # Support specifying a call-seq like `to_s -> string`
+      rdoc_method.call_seq.gsub(/^\s*([^(\s]+)(.*?)(?: -> (.+))?$/) do
+        "<code><b>#{h $1}</b>#{h $2}</code>#{" &rarr; <code>#{h $3}</code>" if $3}"
+      end
     else
-      "<code>#{h rdoc_method.name}#{h rdoc_method.params}</code>"
+      "<code><b>#{h rdoc_method.name}</b>#{h rdoc_method.params}</code>"
     end
   end
 

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -593,7 +593,7 @@ describe SDoc::Helpers do
         module Foo; def bar(qux); end; end
       RUBY
 
-      _(@helpers.method_signature(method)).must_equal "<code>bar(qux)</code>"
+      _(@helpers.method_signature(method)).must_equal "<code><b>bar</b>(qux)</code>"
     end
 
     it "escapes the method signature" do
@@ -601,7 +601,7 @@ describe SDoc::Helpers do
         module Foo; def bar(op = :<, &block); end; end
       RUBY
 
-      _(@helpers.method_signature(method)).must_equal "<code>bar(op = :&lt;, &amp;block)</code>"
+      _(@helpers.method_signature(method)).must_equal "<code><b>bar</b>(op = :&lt;, &amp;block)</code>"
     end
 
     it "handles :call-seq: documentation" do
@@ -620,13 +620,13 @@ describe SDoc::Helpers do
       RUBY
 
       _(@helpers.method_signature(mod.find_method("bar", false))).must_equal <<~HTML.chomp
-        <code>bar(op = :&lt;)</code>
-        <code>bar(&amp;block)</code>
+        <code><b>bar</b>(op = :&lt;)</code>
+        <code><b>bar</b>(&amp;block)</code>
       HTML
 
       _(@helpers.method_signature(mod.find_method("qux", false))).must_equal <<~HTML.chomp
-        <code>qux(&amp;block)</code> &rarr; <code>self</code>
-        <code>qux</code> &rarr; <code>Enumerator</code>
+        <code><b>qux</b>(&amp;block)</code> &rarr; <code>self</code>
+        <code><b>qux</b></code> &rarr; <code>Enumerator</code>
       HTML
     end
   end


### PR DESCRIPTION
This PR includes a handful of commits that improve readability when using dark mode.

Closes #307.

| Before (Firefox defaults) | After (Firefox defaults) | Before (18px serif, 17px mono) | After (18px serif, 17px mono) |
| --- | --- | --- | --- |
| ![before-dark-defaults](https://github.com/rails/sdoc/assets/771968/067b25b5-71ce-44f0-b43c-8c196c14f1ef) | ![after-dark-defaults](https://github.com/rails/sdoc/assets/771968/df9a8f3b-15e1-4365-8648-fcd6a117bfca) | ![before-dark-custom](https://github.com/rails/sdoc/assets/771968/ae355110-0827-4b67-b69f-a7a380e5fb28) | ![after-dark-custom](https://github.com/rails/sdoc/assets/771968/0de242d0-62c8-4ee5-b2dd-6e9aa3eb2829) |
| ![before-light-defaults](https://github.com/rails/sdoc/assets/771968/3a116acc-2186-430e-ac7b-c856b09c7e9a) | ![after-light-defaults](https://github.com/rails/sdoc/assets/771968/8d3fdfed-6244-4e2c-b3bc-5e079c237b5e) | ![before-light-custom](https://github.com/rails/sdoc/assets/771968/f5198d94-5f32-4257-a922-a437a63972b9) | ![after-light-custom](https://github.com/rails/sdoc/assets/771968/019d4399-7994-4efb-915c-1117e252e303) |
