### PR TITLE
Use fixed positioning for .banner

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -221,6 +221,8 @@ html {
 .banner {
   height: var(--banner-height);
   background-color: var(--brand-color);
+  position: fixed;
+  width: inherit;
 }
 
 .banner__segment {


### PR DESCRIPTION
Prevent the banner from moving relative to the .panel__tray when overscrolling the top:

<img width="730" alt="image" src="https://github.com/rails/sdoc/assets/28561/0df40998-8d8d-40ef-a53c-c8971ef708f4">
