### PR TITLE
Add padding to `<code>` elements in search results

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -646,18 +646,19 @@ html {
   font-style: italic;
 }
 
-.description :is(code, pre) {
+.description pre {
   background: var(--code-bg);
+}
+
+:is(.description p, p.description) code {
+  background: var(--code-bg);
+  padding: 0 0.15em;
+  border-radius: 2px;
 }
 
 /* TODO: Remove this hack when Firefox supports `:has()` */
 .description a code {
   text-decoration: underline var(--code-bg);
-}
-
-.description p code {
-  padding: 0 0.15em;
-  border-radius: 2px;
 }
 
 @media (hover: hover) {


### PR DESCRIPTION
This makes it so that `<code>` elements in search results and `<code>` elements in other `.description` blocks have the same style.