### PR TITLE
Fix breadcrumbs for flattened class declarations

### DIFF
--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -120,14 +120,14 @@ module SDoc::Helpers
   end
 
   def module_breadcrumbs(rdoc_module)
-    crumbs = [h(rdoc_module.name)]
+    parent_names = rdoc_module.full_name.split("::")[0...-1]
 
-    rdoc_module.each_parent do |parent|
-      break if parent.is_a?(RDoc::TopLevel)
-      crumbs.unshift(link_to(h(parent.name), parent))
+    crumbs = parent_names.each_with_index.map do |name, i|
+      parent = rdoc_module.store.find_module_named(parent_names[0..i].join("::"))
+      parent ? link_to(h(name), parent) : h(name)
     end
 
-    "<code>#{crumbs.join("::<wbr>")}</code>"
+    "<code>#{[*crumbs, h(rdoc_module.name)].join("::<wbr>")}</code>"
   end
 
   def module_ancestors(rdoc_module)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -547,6 +547,19 @@ describe SDoc::Helpers do
       _(@helpers.module_breadcrumbs(qux)).
         must_equal "<code>#{@helpers.link_to "Foo", foo}::<wbr>#{@helpers.link_to "Bar", bar}::<wbr>Qux</code>"
     end
+
+    it "handles flattened class declarations" do
+      top_level = rdoc_top_level_for <<~RUBY
+        class Foo::Bar::Qux; end
+      RUBY
+
+      foo = top_level.find_module_named("Foo")
+      bar = top_level.find_module_named("Foo::Bar")
+      qux = top_level.find_module_named("Foo::Bar::Qux")
+
+      _(@helpers.module_breadcrumbs(qux)).
+        must_equal "<code>#{@helpers.link_to "Foo", foo}::<wbr>#{@helpers.link_to "Bar", bar}::<wbr>Qux</code>"
+    end
   end
 
   describe "#module_ancestors" do


### PR DESCRIPTION
When declaring a class with a flattened name like `class Foo::Bar` rather than `module Foo; class Bar`, RDoc does not return a parent object for `Bar`.  Note this only applies to classes.  When `Bar` is merely a module, RDoc _does_ return a parent object.

That behavior caused `module_breadcrumbs` to return only the class's name in such cases.  This commit fixes `module_breadcrumbs` to work around that behavior and always return all breadcrumbs.