### PR TITLE
Remove `RDoc::Options#search_index`

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -18,7 +18,6 @@ class RDoc::Options
   end
 
   attr_accessor :github
-  attr_accessor :search_index
 end
 
 class RDoc::Generator::SDoc


### PR DESCRIPTION
The code that used this attribute was removed in 73ace3664fe28d9afe2d4533539d707777c0839f.