### PR TITLE
Rework method spotlight effect

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -132,16 +132,6 @@ th
   font-size: 1.15em;
 }
 
-@keyframes spotlight {
-  from { background-color: yellow; }
-  to { background-color: white; }
-}
-
-.spotlight {
-  animation-name: spotlight;
-  animation-duration: 1s;
-}
-
 .sr-only {
   position: absolute;
   width: 1px;
@@ -588,6 +578,18 @@ html {
   font-size: 1rem;
   font-weight: normal;
   white-space: pre-wrap;
+
+  position: relative;
+}
+
+:target .method__signature h3::before {
+  content: " ";
+
+  position: absolute;
+  left: calc(-5px - var(--space-sm));
+  border-left: 5px solid var(--link-color);
+  border-radius: 5px;
+  height: 100%;
 }
 
 .method__permalink {

--- a/lib/rdoc/generator/template/rails/resources/js/main.js
+++ b/lib/rdoc/generator/template/rails/resources/js/main.js
@@ -1,25 +1,5 @@
 import { Search } from "./search.js";
 
-window.spotlight = function(url) {
-  var hash = url.match(/#([^#]+)$/);
-  if (hash) {
-    var link = document.querySelector('a[name=' + hash[1] + ']');
-    if(link) {
-      var parent = link.parentElement;
-
-      parent.classList.add('spotlight');
-
-      setTimeout(function() {
-        parent.classList.remove('spotlight');
-      }, 1000);
-    }
-  }
-};
-
-document.addEventListener("turbo:load", function() {
-  spotlight('#' + location.hash);
-});
-
 document.addEventListener("turbo:load", () => {
   const searchInput = document.getElementById("search");
   const searchOutput = document.getElementById("results");
@@ -77,6 +57,26 @@ document.addEventListener("turbo:click", ({ target }) => {
     document.getElementById("results").scrollTop = scrollTop
   })
 })()
+
+
+// Turbo Drive interferes with the browser designating the `:target` element for
+// CSS. See https://github.com/hotwired/turbo/issues/592.
+//
+// Therefore, disable Turbo Drive for intra-page link clicks...
+document.addEventListener("turbo:click", event => {
+  const targetUrl = new URL(event.detail.url);
+  if (targetUrl.hash && targetUrl.href === new URL(targetUrl.hash, location).href) {
+    event.preventDefault();
+  }
+});
+// ...and, if appropriate, trigger an intra-page navigation after `turbo:load`.
+document.addEventListener("turbo:load", event => {
+  if (location.hash) {
+    const a = document.createElement("a");
+    a.href = location;
+    a.click();
+  }
+});
 
 
 document.addEventListener("turbo:load", function () {


### PR DESCRIPTION
a67ece6220f8da3ed7f3319b89550234d1728382 changed the HTML around method permalinks, which broke the spotlight effect when navigating to a specific method.  However, prior to that commit (since upgrading to Turbo v7), the spotlight effect only worked for cross-page navigation, not intra-page navigation.  This commit fixes the spotlight effect for both cross-page and intra-page navigation.

Additionally, this commit changes the visual effect from a momentary flash of yellow to a persistent mark in the left margin.  This ensures that effect is not missed (for example, when opening the page as a background tab), and is less jarring when using dark mode.

| Before | After |
| --- | --- |
| ![before-light](https://github.com/rails/sdoc/assets/771968/b1fbffcf-f40f-4790-8f74-cd6d351e8559) | ![after-light](https://github.com/rails/sdoc/assets/771968/487fd78d-e67f-48e6-aa07-60205da3c3e3) |
| ![before-dark](https://github.com/rails/sdoc/assets/771968/17e71237-ebe0-4c6b-9e34-6efa7d9bc685) | ![after-dark](https://github.com/rails/sdoc/assets/771968/6bfa5121-8549-4e57-b6cb-887fa8e7d87f) |
