### PR TITLE
Update `vendor_javascript` Rake task to download ESM

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -108,8 +108,7 @@ task :vendor_javascript do
   packager = Importmap::Packager.new(vendor_path: "#{ASSETS_PATH}/js")
   imports = packager.import("@hotwired/turbo", from: "unpkg")
   imports.each do |package, url|
-    umd_url = url.gsub("esm.js", "umd.js")
-    puts %(Vendoring "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{umd_url})
-    packager.download(package, umd_url)
+    puts %(Vendoring "#{package}" to #{packager.vendor_path}/#{package}.js via download from #{url})
+    packager.download(package, url)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -101,6 +101,7 @@ end
 
 ASSETS_PATH = "lib/rdoc/generator/template/rails/resources"
 
+desc "Download and vendor JavaScript assets"
 task :vendor_javascript do
   module Importmap; end
   require "importmap/packager"

--- a/lib/rdoc/generator/template/rails/resources/js/@hotwired--turbo.js
+++ b/lib/rdoc/generator/template/rails/resources/js/@hotwired--turbo.js
@@ -22,19 +22,19 @@ Copyright © 2023 37signals LLC
 
 /**
  * The MIT License (MIT)
- *
+ * 
  * Copyright (c) 2019 Javan Makhmali
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
Follow-up to 5687727c1301e27c82bd6af25746d5f676d69b24.

This updates the `vendor_javascript` Rake task to download the ESM version of the JavaScript package instead of the UMD version.
