### PR TITLE
Remove scroll-to-top button

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -1,5 +1,3 @@
-<a href="#" class="back-to-top"></a>
-
 <nav id="panel" class="panel">
   <div class="banner">
     <div class="banner__segment">

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -161,22 +161,6 @@ th
   font-size: 2rem;
 }
 
-a.back-to-top {
-  visibility: hidden;
-  position: fixed;
-  z-index: 1;
-  right: 1em;
-  bottom: 1em;
-  padding: 2em;
-  border-radius: 3em;
-  background: url('../i/up_white_arrow.png') no-repeat center center, #c52f24;
-  background-size: 2em;
-}
-
-a.back-to-top.show {
-  visibility: visible;
-}
-
 
 /*
  * Navigation panel

--- a/lib/rdoc/generator/template/rails/resources/js/main.js
+++ b/lib/rdoc/generator/template/rails/resources/js/main.js
@@ -77,17 +77,3 @@ document.addEventListener("turbo:load", event => {
     a.click();
   }
 });
-
-
-document.addEventListener("turbo:load", function () {
-  const backToTop = document.querySelector("a.back-to-top");
-
-  backToTop.addEventListener("click", event => {
-    event.preventDefault();
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  });
-
-  document.addEventListener("scroll", event => {
-    backToTop.classList.toggle("show", window.scrollY > 300)
-  }, { passive: true });
-})


### PR DESCRIPTION
Since d0e2ead20f0ca159503b2871667452abcedd4c2e, the table of contents for a page is now in the sidebar / mobile menu instead of at the top of the page, which eliminates the major use case for a scroll-to-top button.

Furthermore, there are alternative ways to scroll to the top of the page.  On desktop, the user can click the scoll bar or press the <kbd>Home</kbd> key.  On mobile, the UX is less consistent, but still possible.  For example, in iOS, the user can double-tap the status bar, whereas Android has its own gestures.  While a scroll-to-top button could provide a unified UX, due to limited screenspace, it is even more likely to obscure content and be in the way.

Also, it is worth pointing out that one of uBlock Origin's bundled filter lists ("EasyList - Annoyances") [blocks scroll-to-top buttons][]. This suggests that many people do not consider such buttons helpful.

[blocks scroll-to-top buttons]: https://github.com/easylist/easylist/blob/2d0b2d2295c9aa8b51deb21ff77da6824dcc24df/fanboy-addon/fanboy_annoyance_general_hide.txt#L498