### PR TITLE
Use sans-serif font

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -3,6 +3,7 @@
 body {
   margin: 0;
   min-height: 100dvh;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 :root {


### PR DESCRIPTION
I find the serif font hard to read. Most websites on the internet use a sans-serif font, so I actually thought the serif font was a mistake. In this PR, I'm setting the font-family for the `<body>` to what Tailwind refers to as [font-sans](https://tailwindcss.com/docs/font-family).


# Before

<img width="2032" alt="Screenshot 2023-10-09 at 11 18 04 PM" src="https://github.com/rails/sdoc/assets/5104186/622aa594-4086-4619-a024-48a906daf1cc">

<img width="2032" alt="Screenshot 2023-10-09 at 11 15 29 PM" src="https://github.com/rails/sdoc/assets/5104186/0be49e26-40a6-4bbe-b0c0-d6e13b8c2918">

# After

<img width="2032" alt="Screenshot 2023-10-09 at 11 14 45 PM" src="https://github.com/rails/sdoc/assets/5104186/71e9d9bb-5377-4071-870c-f18a30c22c6f">

<img width="2032" alt="Screenshot 2023-10-09 at 11 15 20 PM" src="https://github.com/rails/sdoc/assets/5104186/618b278d-45f5-4a84-982b-ad900a7b5180">

