### PR TITLE
Set `max-width` for `#content`

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -505,6 +505,7 @@ html {
     margin-top: calc(-1 * var(--banner-height));
     margin-left: var(--panel-width);
     padding: var(--space-lg) var(--space-xl);
+    max-width: calc(75ch + 2 * var(--space-xl));
   }
 }
 


### PR DESCRIPTION
This enforces a maximum width of approximately 75 characters so that lines don't become too long on wide screens.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/05ac8b4e-0f6b-4fad-8c1e-8929ae1566f3) | ![after](https://github.com/rails/sdoc/assets/771968/2b0fb80d-20da-4a52-841c-014677ce1a75) |

The trade-off here is that code examples with long lines are more likely to be cut off.
