### PR TITLE
Add tip about explicitly searching for methods

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -346,10 +346,29 @@ html {
   scroll-padding: var(--space) 0;
 }
 
+
+.panel__results::before {
+  display: block;
+  text-align: center;
+  text-wrap: balance;
+  padding-bottom: var(--space);
+
+  font-size: 0.9em;
+  font-style: italic;
+  color: color-mix(in srgb, currentColor 70%, transparent);
+
+  content: "TIP: Prefix query with \"#\" or \".\" to search for methods.";
+}
+
+/* Hide TIP when one of the first three search results is a method. */
+.panel__results:has(.results__result:nth-child(n+1):nth-child(-n+3) .result__method:not(:empty))::before {
+  display: none;
+}
+
 .panel__results:empty::before {
   content: "No results.";
-  font-style: italic;
 }
+
 
 .results__result:not(:first-child) {
   margin-top: var(--space-lg);
@@ -373,6 +392,7 @@ html {
     border-color: var(--link-hover-color);
   }
 }
+
 
 .result__link {
   display: flex;


### PR DESCRIPTION
This adds a tip above the search results with instructions on how to explicitly search for methods.  The tip is hidden (in browsers that support the `:has()` selector) when one of the first three search results is a method.

| Before | After |
| --- | --- |
| ![before1](https://github.com/rails/sdoc/assets/771968/0c3efde4-a81a-497e-9e61-68e24a28ac92) | ![after1](https://github.com/rails/sdoc/assets/771968/7dd6acd0-cc70-4db5-b407-b9a2c2ef69a8) |
| ![before-after2](https://github.com/rails/sdoc/assets/771968/1b004f84-4ef2-4cb8-8437-ef4c10c5f784) | ![before-after2](https://github.com/rails/sdoc/assets/771968/1b004f84-4ef2-4cb8-8437-ef4c10c5f784) **(same)** |
