### PR TITLE
Fix search results initial scroll position

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -442,7 +442,9 @@ html {
   font-size: 0.9em;
   font-style: italic;
   color: color-mix(in srgb, currentColor 70%, transparent);
+}
 
+.panel__results.active::before {
   content: "TIP: Prefix query with \"#\" or \".\" to search for methods.";
 }
 


### PR DESCRIPTION
When search results are rendered, the result cursor is set to the first result and is scrolled into view via `scrollIntoView({block: "nearest"})`. Typically, this call to `scrollIntoView` would be a no-op.  However, 6eb2e4293638034ce078449510867a537aff7f03 added a "TIP" at the top of the results container.  Thus if the results container has `max-height: 0`, the `scrollIntoView` call will set the scroll position below the "TIP". Such is the case when clicking a `.query-button` or using the `?q=` URL param, because the `.active` class is not yet applied to the results container.

This commit modifies the CSS so that the "TIP" is only shown when the `.active` class is applied.  Thus the `scrollIntoView` call will remain a no-op even when the results container has `max-height: 0`.