### PR TITLE
Exclude downcased acronym bigrams

### DIFF
--- a/lib/sdoc/search_index.rb
+++ b/lib/sdoc/search_index.rb
@@ -36,14 +36,14 @@ module SDoc::SearchIndex
     # Example: "ActiveSupport::Cache::Store" => ":ActiveSupport:Cache:Store"
     strings = [":#{name}".gsub("::", ":")]
 
+    # Example: ":ActiveModel:API" => ":activemodel:api"
+    strings.concat(strings.map(&:downcase))
     # Example: ":ActiveSupport:HashWithIndifferentAccess" => ":AS:HWIA"
     strings.concat(strings.map { |string| string.gsub(/([A-Z])[a-z]+/, '\1') })
     # Example: ":AbstractController:Base#action_name" => " AbstractController Base action_name"
     strings.concat(strings.map { |string| string.tr(":#", " ") })
     # Example: ":AbstractController:Base#action_name" => ":AbstractController:Base#actionname"
     strings.concat(strings.map { |string| string.tr("_", "") })
-    # Example: ":ActiveModel:API" => ":activemodel:api"
-    strings.concat(strings.map(&:downcase))
 
     # Example: ":ActiveModel:Name#<=>" => [":ActiveModel", ":Name", "#<=>"]
     strings.map! { |string| string.split(/(?=[ :#])/) }.flatten!

--- a/spec/search_index_spec.rb
+++ b/spec/search_index_spec.rb
@@ -99,10 +99,10 @@ describe SDoc::SearchIndex do
       _(bigrams).wont_include "GR"
     end
 
-    it "includes downcased bigrams" do
+    it "includes downcased bigrams except for acronym bigrams" do
       bigrams = SDoc::SearchIndex.derive_bigrams("AbcDefGhi::RstUvwXyz")
 
-      bigrams.grep(/[A-Z]/).each do |uppercase|
+      bigrams.grep(/[A-Z]/).grep_v(/[A-Z]{2}/).each do |uppercase|
         _(bigrams).must_include uppercase.downcase
       end
     end


### PR DESCRIPTION
This prevents some unexpected results.  For example, matching `ActionCable::Connection::StreamEventLoop` when searching for "select" due to "S"tream"E"vent"L"oop.