### PR TITLE
Preload search JavaScript modules

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -6,6 +6,9 @@
 <link rel="preload" href="/fonts/Jost-Italic.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="/fonts/RobotoMono-Roman.woff2" as="font" type="font/woff2" crossorigin>
 
+<link rel="modulepreload" href="/js/search-index.js">
+<link rel="modulepreload" href="/js/search.js">
+
 <link rel="stylesheet" href="/css/main.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="/css/highlight.css" type="text/css" media="screen" />
 


### PR DESCRIPTION
This circumvents the `main.js` => `search.js` => `search_index.js` request chain to increase initial page load speed.