### PR TITLE
Switch from bigrams to trigrams for search

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/search.js
+++ b/lib/rdoc/generator/template/rails/resources/js/search.js
@@ -40,8 +40,8 @@ export class Search {
     const bitPositions = [];
 
     for (let i = 0, len = query.length; i < len; i += 1) {
-      const bigram = i === 0 ? (" " + query[0]) : query.substring(i - 1, i + 1);
-      const position = searchIndex.bigrams[bigram];
+      const ngram = i === 0 ? (" " + query[0]) : query.substring(i - 1, i + 1);
+      const position = searchIndex.ngrams[ngram];
 
       if (position) {
         bitPositions.push(position);

--- a/lib/rdoc/generator/template/rails/resources/js/search.js
+++ b/lib/rdoc/generator/template/rails/resources/js/search.js
@@ -37,17 +37,17 @@ export class Search {
   }
 
   compileQuery(query) {
+    query = ` ${query} `;
     const bitPositions = [];
 
-    for (let i = 0, len = query.length; i < len; i += 1) {
-      const ngram = i === 0 ? (" " + query[0]) : query.substring(i - 1, i + 1);
+    for (let i = 0, upto = query.length - 2; i < upto; i += 1) {
+      const ngram = query.substring(i, i + 3);
       const position = searchIndex.ngrams[ngram];
 
       if (position) {
         bitPositions.push(position);
       }
     }
-
     return bitPositions;
   }
 

--- a/lib/sdoc/search_index.rb
+++ b/lib/sdoc/search_index.rb
@@ -18,16 +18,16 @@ module SDoc::SearchIndex
     # all of Foo::Bar's RDoc::MethodAttr instances.
     rdoc_objects = rdoc_modules + rdoc_modules.flat_map(&:method_list).uniq
 
-    bigram_sets = rdoc_objects.map { |rdoc_object| derive_bigrams(rdoc_object.full_name) }
-    bigram_bit_positions = compile_bigrams(bigram_sets)
-    bit_weights = compute_bit_weights(bigram_bit_positions)
+    ngram_sets = rdoc_objects.map { |rdoc_object| derive_ngrams(rdoc_object.full_name) }
+    ngram_bit_positions = compile_ngrams(ngram_sets)
+    bit_weights = compute_bit_weights(ngram_bit_positions)
 
-    entries = rdoc_objects.zip(bigram_sets).map do |rdoc_object, bigrams|
+    entries = rdoc_objects.zip(ngram_sets).map do |rdoc_object, ngrams|
       rdoc_module, rdoc_method = rdoc_object.is_a?(RDoc::ClassModule) ? [rdoc_object] : [rdoc_object.parent, rdoc_object]
       description = rdoc_object.description
 
       [
-        generate_fingerprint(bigrams, bigram_bit_positions),
+        generate_fingerprint(ngrams, ngram_bit_positions),
         compute_tiebreaker_bonus(rdoc_module.full_name, rdoc_method&.name, description),
         rdoc_object.path,
         rdoc_module.full_name,
@@ -36,10 +36,10 @@ module SDoc::SearchIndex
       ]
     end
 
-    { "bigrams" => bigram_bit_positions, "weights" => bit_weights, "entries" => entries }
+    { "ngrams" => ngram_bit_positions, "weights" => bit_weights, "entries" => entries }
   end
 
-  def derive_bigrams(name)
+  def derive_ngrams(name)
     # Example: "ActiveSupport::Cache::Store" => ":ActiveSupport:Cache:Store"
     strings = [":#{name}".gsub("::", ":")]
 
@@ -65,15 +65,15 @@ module SDoc::SearchIndex
     strings.flat_map { |string| string.each_char.each_cons(2).map(&:join) }.uniq
   end
 
-  def compile_bigrams(bigram_sets)
-    # Assign each bigram a bit position based on its rarity. More common bigrams
+  def compile_ngrams(ngram_sets)
+    # Assign each ngram a bit position based on its rarity. More common ngrams
     # come first. This reduces the average number of bytes required to store a
     # fingerprint.
-    bigram_sets.flatten.tally.sort_by(&:last).reverse.map(&:first).each_with_index.to_h
+    ngram_sets.flatten.tally.sort_by(&:last).reverse.map(&:first).each_with_index.to_h
   end
 
-  def generate_fingerprint(bigrams, bigram_bit_positions)
-    bit_positions = bigrams.map(&bigram_bit_positions)
+  def generate_fingerprint(ngrams, ngram_bit_positions)
+    bit_positions = ngrams.map(&ngram_bit_positions)
     byte_count = ((bit_positions.max + 1) / 8.0).ceil
     bytes = [0] * byte_count
 
@@ -84,16 +84,16 @@ module SDoc::SearchIndex
     Uint8Array.new(bytes)
   end
 
-  BIGRAM_PATTERN_WEIGHTS = {
+  NGRAM_PATTERN_WEIGHTS = {
     /[^a-z]/ => 2, # Bonus point for non-lowercase-alpha chars because they show intentionality.
     /^ / => 3, # More points for matching generic start of token.
     /^:/ => 4, # Even more points for explicit start of token.
     /[#.(]/ => 50, # Strongly prefer methods when query includes "#", ".", or "(".
   }
 
-  def compute_bit_weights(bigram_bit_positions)
-    weights = bigram_bit_positions.uniq(&:last).sort_by(&:last).map do |bigram, _position|
-      BIGRAM_PATTERN_WEIGHTS.map { |pattern, weight| bigram.match?(pattern) ? weight : 1 }.max
+  def compute_bit_weights(ngram_bit_positions)
+    weights = ngram_bit_positions.uniq(&:last).sort_by(&:last).map do |ngram, _position|
+      NGRAM_PATTERN_WEIGHTS.map { |pattern, weight| ngram.match?(pattern) ? weight : 1 }.max
     end
 
     Uint8Array.new(weights)
@@ -102,8 +102,8 @@ module SDoc::SearchIndex
   def compute_tiebreaker_bonus(module_name, method_name, description)
     method_name ||= ""
 
-    # Bonus is per matching bigram and is very small so it does not outweigh
-    # points from other matches. Longer names have smaller per-bigram bonuses,
+    # Bonus is per matching ngram and is very small so it does not outweigh
+    # points from other matches. Longer names have smaller per-ngram bonuses,
     # but the value scales down very slowly.
     bonus = 0.01 / (module_name.length + method_name.length) ** 0.025
 

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -38,7 +38,7 @@ describe RDoc::Generator::SDoc do
         index = File.read("doc/js/search-index.js")
         index.delete_prefix!("export default ").delete_suffix!(";")
         index.gsub!(/\(new Uint8Array\((.+?)\)\)/, '\1')
-        _(JSON.parse(index).keys.sort).must_equal ["bigrams", "entries", "weights"]
+        _(JSON.parse(index).keys.sort).must_equal ["ngrams", "weights", "entries"].sort
       end
     end
   end

--- a/spec/rdoc_generator_spec.rb
+++ b/spec/rdoc_generator_spec.rb
@@ -35,9 +35,10 @@ describe RDoc::Generator::SDoc do
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         rdoc_run("--files", "#{__dir__}/../README.md", "#{__dir__}/../lib/sdoc/version.rb")
-        contents = File.read("doc/js/search-index.js")
-        index = JSON.parse(contents.delete_prefix!("export default ").delete_suffix!(";"))
-        _(index.keys.sort).must_equal ["bigrams", "entries", "weights"]
+        index = File.read("doc/js/search-index.js")
+        index.delete_prefix!("export default ").delete_suffix!(";")
+        index.gsub!(/\(new Uint8Array\((.+?)\)\)/, '\1')
+        _(JSON.parse(index).keys.sort).must_equal ["bigrams", "entries", "weights"]
       end
     end
   end

--- a/spec/search_index_spec.rb
+++ b/spec/search_index_spec.rb
@@ -23,7 +23,7 @@ describe SDoc::SearchIndex do
       _(search_index["entries"].length).must_equal 2
       search_index["entries"].each do |entry|
         _(entry.length).must_be :<=, 6
-        _(entry[0]).must_be_instance_of Array # Fingerprint
+        _(entry[0]).must_be_kind_of Array # Fingerprint
         _(entry[1]).must_be :<, 1.0 # Tiebreaker bonus
       end
 


### PR DESCRIPTION
Trigrams can provide more accurate search results than bigrams.  For example, using bigrams, searching for "sel" would attempt to match the ngrams " s", "se", and "el".  For the Rails API (at `7c65a4b83b583f4f`), the top result is `ActiveModel::Serializers` due to "Model" matching "el" and ":Serial" matching " s" and "se".  However, using trigrams, "sel" would attempt to match " se" and "sel".  In that case, for the Rails API, the top result is `ActiveRecord::QueryMethods#select`.

The downside to using trigrams is that the search index increases from 2.9 MB to 8.6 MB.  But the data compresses well, so when gzipped the size only increases from 474 kB to 670 kB.  And browser heap snapshot size stays reasonably small, increasing from 6.8 MB to 11.1 MB in Firefox and 8.0 MB to 22.2 MB in Chrome.