### PR TITLE
Version explicit links to `api.rubyonrails.org`

### DIFF
--- a/lib/sdoc/postprocessor.rb
+++ b/lib/sdoc/postprocessor.rb
@@ -10,7 +10,7 @@ module SDoc::Postprocessor
     document = Nokogiri::HTML5.parse(rendered)
 
     rebase_urls!(document)
-    version_rails_guides_urls!(document)
+    version_rubyonrails_urls!(document)
     add_ref_link_classes!(document)
     unify_h1_headings!(document)
     highlight_code_blocks!(document)
@@ -49,9 +49,12 @@ module SDoc::Postprocessor
     end
   end
 
-  def version_rails_guides_urls!(document)
+  def version_rubyonrails_urls!(document)
     if ENV["HORO_PROJECT_NAME"] == "Ruby on Rails" && version = ENV["HORO_PROJECT_VERSION"]
-      document.css("a[href^='https://guides.rubyonrails.org/']").each do |element|
+      document.css(
+        "a[href^='https://api.rubyonrails.org/']",
+        "a[href^='https://guides.rubyonrails.org/']"
+      ).each do |element|
         element["href"] = version_url(element["href"], version)
       end
     end


### PR DESCRIPTION
Similar to ffcaf8184e5a30a61038010cbde7d8ea5bfaab83, this uses postprocessing to version explicit links to api.rubyonrails.org.  For example, if `ENV["HORO_PROJECT_VERSION"]` is "3.2.1" (and `ENV["HORO_PROJECT_NAME"]` is "Ruby on Rails"), then

  ```html
  <a href="https://api.rubyonrails.org/classes/ActiveRecord/Base.html">Learn more</a>
  ```

will be changed to

  ```html
  <a href="https://api.rubyonrails.org/v3.2.1/classes/ActiveRecord/Base.html">Learn more</a>
  ```

This allows such URLs to be used in `README.rdoc` files instead of using `link:classes/ActiveRecord/Base.html`, which is not properly resolved when the link is rendered on e.g. GitHub.
