### PR TITLE
fix: Updated check logic for `token_stream` existence

### DIFF
--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -218,7 +218,7 @@ module SDoc::Helpers
   end
 
   def method_source_code_and_url(rdoc_method)
-    source_code = rdoc_method.markup_code if rdoc_method.token_stream
+    source_code = rdoc_method.markup_code if rdoc_method.token_stream&.any?
 
     if source_code&.match(/File\s(\S+), line (\d+)/)
       source_url = github_url($1, line: $2)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -867,12 +867,11 @@ describe SDoc::Helpers do
         end
       RUBY
 
-      source_code, source_url = @helpers.method_source_code_and_url(method)
+      source_code, _source_url = @helpers.method_source_code_and_url(method)
 
       _(source_code).must_be_nil
       # Unfortunately, _source_url is also nil because RDoc does not provide the
       # source code location in this case.
-      _(source_url).must_be_nil
     end
 
     it "returns nil GitHub URL when options.github is false" do

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -867,11 +867,12 @@ describe SDoc::Helpers do
         end
       RUBY
 
-      source_code, _source_url = @helpers.method_source_code_and_url(method)
+      source_code, source_url = @helpers.method_source_code_and_url(method)
 
       _(source_code).must_be_nil
       # Unfortunately, _source_url is also nil because RDoc does not provide the
       # source code location in this case.
+      _(source_url).must_be_nil
     end
 
     it "returns nil GitHub URL when options.github is false" do


### PR DESCRIPTION
Due to the change in https://github.com/ruby/rdoc/pull/1055, `token_stream` returns empty Array instead of `nil`,
so update check logic for `token_stream` existence.

---

The comment says "source_url is also nil", so add a test to cover that case.