### PR TITLE
Fix 1px width difference between banner and tray

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -342,6 +342,7 @@ html {
 .banner {
   height: var(--banner-height);
   background-color: var(--brand-color);
+  box-shadow: 1px 0px var(--brand-color); /* Match .panel_tray width on desktop */
 }
 
 .banner__segment {
@@ -658,7 +659,7 @@ html {
 
   .panel__tray {
     height: unset;
-    border-right: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+    box-shadow: 1px 0 color-mix(in srgb, currentColor 25%, transparent);
   }
 
   .panel__results.active {


### PR DESCRIPTION
This fixes a 1px width difference between `.banner` and `.panel__tray` on desktop due to the additional border on `.panel__tray`.  Mobile is unaffected.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/2124b643-31ac-48ac-9540-d5c9d294ac5c) | ![after](https://github.com/rails/sdoc/assets/771968/9b394b6e-ccbc-4542-959c-cce09f7c64bc) |
