### PR TITLE
Fix font size of nested code elements

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -95,7 +95,11 @@ body {
 
 pre, code, .kind {
   font-family: var(--monospace-font);
-  font-size: .95em;
+  font-size: 0.95em;
+}
+
+:where(pre, code, .kind) > :is(pre, code, .kind) {
+  font-size: unset;
 }
 
 .kind::after {


### PR DESCRIPTION
Prior to this commit, code blocks wrapped in `<pre><code>` had `font-size: 0.95em` applied twice, resulting in a font size of 0.9025em (e.g. 18.05px instead of 19px when the body font size is 20px).  This commit fixes such elements to have the intended font size.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/96c2a9f3-dede-4a0b-a552-01a24c49281b) | ![after](https://github.com/rails/sdoc/assets/771968/aa2d72ce-dfcf-4c00-8789-d9d2482ddad7) |
