### PR TITLE
Fix multi-line `:call-seq:` method signatures

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -772,6 +772,11 @@ html {
   white-space: pre-wrap;
 }
 
+.method__signature code .returns {
+  font-family: var(--body-font);
+  font-size: 1.1em;
+}
+
 .target .method__signature code::before {
   content: " ";
 

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -207,14 +207,16 @@ module SDoc::Helpers
   end
 
   def method_signature(rdoc_method)
-    if rdoc_method.call_seq
+    signature = if rdoc_method.call_seq
       # Support specifying a call-seq like `to_s -> string`
       rdoc_method.call_seq.gsub(/^\s*([^(\s]+)(.*?)(?: -> (.+))?$/) do
-        "<code><b>#{h $1}</b>#{h $2}</code>#{" &rarr; <code>#{h $3}</code>" if $3}"
+        "<b>#{h $1}</b>#{h $2}#{" <span class=\"returns\">&rarr;</span> #{h $3}" if $3}"
       end
     else
-      "<code><b>#{h rdoc_method.name}</b>#{h rdoc_method.params}</code>"
+      "<b>#{h rdoc_method.name}</b>#{h rdoc_method.params}"
     end
+
+    "<code>#{signature}</code>"
   end
 
   def method_source_code_and_url(rdoc_method)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -813,13 +813,13 @@ describe SDoc::Helpers do
       RUBY
 
       _(@helpers.method_signature(mod.find_method("bar", false))).must_equal <<~HTML.chomp
-        <code><b>bar</b>(op = :&lt;)</code>
-        <code><b>bar</b>(&amp;block)</code>
+        <code><b>bar</b>(op = :&lt;)
+        <b>bar</b>(&amp;block)</code>
       HTML
 
       _(@helpers.method_signature(mod.find_method("qux", false))).must_equal <<~HTML.chomp
-        <code><b>qux</b>(&amp;block)</code> &rarr; <code>self</code>
-        <code><b>qux</b></code> &rarr; <code>Enumerator</code>
+        <code><b>qux</b>(&amp;block) <span class="returns">&rarr;</span> self
+        <b>qux</b> <span class="returns">&rarr;</span> Enumerator</code>
       HTML
     end
   end


### PR DESCRIPTION
Follow-up to 65c34da1fbd210158520e00636c1d161581722e4.

This fixes the `method_signature` helper to handle multi-line `:call-seq:` method signatures by wrapping the entire signature in `<code>` (which is styled with `white-space: pre-wrap`).
