### PR TITLE
Remove extra whitespace in method signature params

### DIFF
--- a/lib/sdoc/rdoc_monkey_patches.rb
+++ b/lib/sdoc/rdoc_monkey_patches.rb
@@ -9,6 +9,13 @@ RDoc::TopLevel.prepend(Module.new do
 end)
 
 
+RDoc::AnyMethod.prepend(Module.new do
+  def params
+    super&.sub(/\A\(\s+/, "(")&.sub(/\s+\)\z/, ")")
+  end
+end)
+
+
 RDoc::Markup::ToHtmlCrossref.prepend(Module.new do
   def cross_reference(name, text = nil, code = true)
     if text

--- a/spec/rdoc_monkey_patches_spec.rb
+++ b/spec/rdoc_monkey_patches_spec.rb
@@ -12,6 +12,23 @@ describe "RDoc monkey patches" do
     end
   end
 
+  describe RDoc::AnyMethod do
+    it "omits extra whitespace in #params" do
+      rdoc_method = rdoc_top_level_for(<<~RUBY).find_module_named("Foo").find_method("bar", false)
+        module Foo
+          def bar(
+            x,
+            y,
+            z
+          )
+          end
+        end
+      RUBY
+
+      _(rdoc_method.params).must_equal "(x, y, z)"
+    end
+  end
+
   describe RDoc::Markup::ToHtmlCrossref do
     it "prevents unintentional ref links" do
       description = rdoc_top_level_for(<<~RUBY).find_module_named("CoolApp").description


### PR DESCRIPTION
RDoc includes extra whitespace in a method's parameter list when the the method's `def` statement is spread across multiple lines.  For example, a `def` like:

  ```ruby
  def define_attribute(
    name,
    cast_type,
    default: NO_DEFAULT_PROVIDED,
    user_provided_default: true
  )
    # ...
  end
  ```

Would produce a parameter list like:

  ```
  ( name, cast_type, default: NO_DEFAULT_PROVIDED, user_provided_default: true )
  ```

This commit monkey-patches `RDoc::AnyMethod#params` to remove the extra whitespace within the parentheses:

  ```
  (name, cast_type, default: NO_DEFAULT_PROVIDED, user_provided_default: true)
  ```

This is implemented as a monkey patch so that it fixes `params` for rendered method docs as well as search index entries.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/16dfd82b-e8c1-4851-be62-6880815c8785) | ![after](https://github.com/rails/sdoc/assets/771968/2066698e-6e3c-41e6-8ce1-2a807c6484d4) |
