### PR TITLE
Extract basic `:call-seq:` params for search results

### DIFF
--- a/lib/sdoc/search_index.rb
+++ b/lib/sdoc/search_index.rb
@@ -113,7 +113,19 @@ module SDoc::SearchIndex
 
   def signature_for(rdoc_method)
     sigil = rdoc_method.singleton ? "::" : "#"
-    params = rdoc_method.call_seq ? "(...)" : rdoc_method.params
+
+    params =
+      case rdoc_method.call_seq&.strip
+      when nil
+        rdoc_method.params
+      when /\A[^ (]+(?: -> .+)?\z/
+        "()"
+      when /\A[^ (]+(\(.*?\))(?: -> .+)?\z/
+        $1
+      else
+        "(...)"
+      end
+
     "#{sigil}#{rdoc_method.name}#{params}"
   end
 


### PR DESCRIPTION
Prior to this commit, search results displayed `(...)` as the parameter list for any `:call-seq:` method.  The reason being the `:call-seq:` value may contain method overloads (i.e. multiple parameter lists) or even arbitrary text.  However, it is common for the `:call-seq:` value to be basic method signature with a single parameter list.  Therefore, this commit handles that case and otherwise falls back to `(...)`.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/8ae055d3-e619-45e6-8d18-08a735688095) | ![after](https://github.com/rails/sdoc/assets/771968/b1aea571-3f8b-428a-a3f0-3810c0db787c) |
