### PR TITLE
Fix `module_breadcrumbs` when parent is a class

### DIFF
--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -182,7 +182,7 @@ module SDoc::Helpers
     parent_names = rdoc_module.full_name.split("::")[0...-1]
 
     crumbs = parent_names.each_with_index.map do |name, i|
-      parent = rdoc_module.store.find_module_named(parent_names[0..i].join("::"))
+      parent = rdoc_module.store.find_class_or_module(parent_names[0..i].join("::"))
       parent ? link_to(h(name), parent) : h(name)
     end
 


### PR DESCRIPTION
`RDoc::Store#find_module_named` does not find classes (though `RDoc::TopLevel#find_module_named` and `RDoc::Context#find_module_named` both do).  Thus, prior to this commit, when a parent module was a class, its breadcrumb would not be linked.

This commit fixes the issue by changing `RDoc::Store#find_module_named` to `RDoc::Store#find_class_or_module`.