### PR TITLE
Skip rendering empty descriptions

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -11,7 +11,7 @@
     <h2 class="content__divider">Required Files</h2>
     <ul>
       <% @context.requires.each do |req| %>
-        <li><%= full_name req.name %></li>
+        <li><%= full_name_for req.name %></li>
       <% end %>
     </ul>
   <% end %>
@@ -24,7 +24,7 @@
       <% ancestors.each do |kind, ancestor| %>
         <li>
           <span class="kind"><%= kind %></span>
-          <%= ancestor.is_a?(String) ? full_name(ancestor) : link_to(ancestor) %>
+          <%= ancestor.is_a?(String) ? full_name_for(ancestor) : link_to(ancestor) %>
         </li>
       <% end %>
     </ul>
@@ -52,11 +52,7 @@
       </div>
     <% end %>
 
-    <% if section.comment then %>
-      <div class="description">
-        <%= section.description %>
-      </div>
-    <% end %>
+    <%= description_for section %>
 
     <% unless constants.empty? %>
       <!-- Section constants -->
@@ -64,11 +60,11 @@
       <table border='0' cellpadding='5'>
         <% constants.each do |const| %>
           <tr valign='top'>
-            <td class="attr-name"><%= short_name const %></td>
+            <td class="attr-name"><%= short_name_for const %></td>
             <td>=</td>
             <td class="attr-value"><%= h const.value %></td>
           </tr>
-          <% if const.comment %>
+          <% if const.comment && !const.comment.empty? %>
             <tr valign='top'>
               <td>&nbsp;</td>
               <td colspan="2" class="attr-desc"><%= const.description.strip %></td>
@@ -88,7 +84,7 @@
             <td class='attr-rw'>
               [<%= attrib.rw %>]
             </td>
-            <td class='attr-name'><%= short_name attrib %></td>
+            <td class='attr-name'><%= short_name_for attrib %></td>
             <td class='attr-desc'><%= attrib.description.strip %></td>
           </tr>
         <% end %>
@@ -116,22 +112,18 @@
             <p class="method__aka">
               Also aliased as:
               <%# Sometimes a parent cannot be determined. See ruby/rdoc@85ebfe13dc. %>
-              <%= method.aliases.map { |aka| link_to_if aka.parent, short_name(aka), aka }.join(", ") %>.
+              <%= method.aliases.map { |aka| link_to_if aka.parent, short_name_for(aka), aka }.join(", ") %>.
             </p>
           <% end %>
 
           <% if alias_for = method.is_alias_for then %>
             <p class="method__aka">
               Alias for:
-              <%= link_to short_name(alias_for), alias_for %>.
+              <%= link_to short_name_for(alias_for), alias_for %>.
             </p>
           <% end %>
 
-          <% if method.comment %>
-            <div class="description">
-              <%= method.description %>
-            </div>
-          <% end %>
+          <%= description_for method %>
 
           <% source_code, source_url = method_source_code_and_url(method) %>
           <% if source_code %>

--- a/lib/rdoc/generator/template/rails/_module_nav.rhtml
+++ b/lib/rdoc/generator/template/rails/_module_nav.rhtml
@@ -1,7 +1,7 @@
 <% unless @context.classes_and_modules.empty? %>
-  <a href="#namespace" class="namespace-link"><%= short_name(@context) %> namespace</a>
+  <a href="#namespace" class="namespace-link"><%= short_name_for(@context) %> namespace</a>
 <% end %>
-<%= button_to_search @context, display_name: short_name(@context) %>
+<%= button_to_search @context, display_name: short_name_for(@context) %>
 
 <% if outline = outline(@context) %>
   <div class="nav__heading">Outline</div>
@@ -14,7 +14,7 @@
   <div class="nav__heading">Methods</div>
   <ul class="nav__list">
     <% methods.each do |rdoc_method| %>
-      <li><%= link_to short_name(rdoc_method), rdoc_method,
+      <li><%= link_to short_name_for(rdoc_method), rdoc_method,
                 class: "ref-link nav__method-link#{"--singleton" if rdoc_method.singleton}" %></li>
     <% end %>
   </ul>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -18,7 +18,7 @@
     <main id="content" class="content">
         <div class="content__title">
           <%= "<h1>" if @context.comment.empty? %>
-            <%= full_name @context %>
+            <%= full_name_for @context %>
           <%= "</h1>" if @context.comment.empty? %>
         </div>
 

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -28,7 +28,7 @@ module SDoc::Helpers
   end
 
   def _link_body(text)
-    text.is_a?(RDoc::CodeObject) ? full_name(text) : text
+    text.is_a?(RDoc::CodeObject) ? full_name_for(text) : text
   end
 
   def link_to_if(condition, text, *args)
@@ -43,19 +43,25 @@ module SDoc::Helpers
     link_to(text, url, html_attributes)
   end
 
-  def button_to_search(query, display_name: full_name(query))
+  def button_to_search(query, display_name: full_name_for(query))
     query = query.full_name if query.is_a?(RDoc::CodeObject)
     %(<button class="query-button" data-query="#{h query} ">Search #{display_name}</button>)
   end
 
-  def full_name(named)
+  def full_name_for(named)
     named = named.full_name if named.is_a?(RDoc::CodeObject)
     "<code>#{named.split(%r"(?<=./|.::)").map { |part| h part }.join("<wbr>")}</code>"
   end
 
-  def short_name(named)
+  def short_name_for(named)
     named = named.name if named.is_a?(RDoc::CodeObject)
     "<code>#{h named}</code>"
+  end
+
+  def description_for(rdoc_object)
+    if rdoc_object.comment && !rdoc_object.comment.empty?
+      %(<div class="description">#{rdoc_object.description}</div>)
+    end
   end
 
   def base_tag_for_context(context)


### PR DESCRIPTION
`RDoc::CodeObject#comment` appears to always return a string, even if no comment has been specified.  Thus the truthiness of `comment` cannot be used to skip rendering empty descriptions.

This commit adds a `description_for` helper to encapsulate properly checking `comment` and wrapping the rendered description in a `div`.

This commit also renames the `full_name` and `short_name` helpers to `full_name_for` and `short_name_for` to match `description_for`.