### PR TITLE
Add constants to search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Main (3.0.0.alpha)
 * [#345](https://github.com/rails/sdoc/pull/345) Version explicit links to `api.rubyonrails.org` [@jonathanhefner](https://github.com/jonathanhefner)
 * [#356](https://github.com/rails/sdoc/pull/356) Redesign "Constants" section [@jonathanhefner](https://github.com/jonathanhefner)
 * [#357](https://github.com/rails/sdoc/pull/357) Support permalinking constants [@jonathanhefner](https://github.com/jonathanhefner)
+* [#358](https://github.com/rails/sdoc/pull/358) Add constants to search index [@jonathanhefner](https://github.com/jonathanhefner)
 
 2.6.1
 =====

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -504,7 +504,7 @@ html {
 }
 
 /* Hide TIP when one of the first three search results is a method. */
-.panel__results:has(.results__result:nth-child(n+1):nth-child(-n+3) .result__method:not(:empty))::before {
+.panel__results:has(.results__result:nth-child(n+1):nth-child(-n+3) .result__member:not(:empty))::before {
   display: none;
 }
 
@@ -542,11 +542,11 @@ html {
   flex-direction: column;
 }
 
-.result__method {
+.result__member {
   display: flex;
 }
 
-.result__method::before {
+.result__member::before {
   content: "\221F";
   font-size: 1.25em;
   margin: -0.3em 0.2em;
@@ -557,7 +557,7 @@ html {
   margin: var(--space-xs) 0 0 0;
 }
 
-:is(.result__method, .result__summary):empty {
+:is(.result__member, .result__summary):empty {
   display: none;
 }
 

--- a/lib/rdoc/generator/template/rails/resources/js/main.js
+++ b/lib/rdoc/generator/template/rails/resources/js/main.js
@@ -3,11 +3,11 @@ import { Search } from "./search.js";
 document.addEventListener("turbo:load", () => {
   const searchInput = document.getElementById("search");
   const searchOutput = document.getElementById("results");
-  const search = new Search(searchInput, searchOutput, (url, module, method, summary) =>
+  const search = new Search(searchInput, searchOutput, (url, module, member, summary) =>
     `<div class="results__result">
       <a class="ref-link result__link" href="${url}">
         <code class="result__module">${module.replaceAll("::", "::<wbr>")}</code>
-        <code class="result__method">${method || ""}</code>
+        <code class="result__member">${member || ""}</code>
       </a>
       <p class="result__summary description">${summary || ""}</p>
     </div>`


### PR DESCRIPTION
This makes constants searchable, just like methods.

| Before | After |
| --- | --- |
| ![before](https://github.com/rails/sdoc/assets/771968/fb2f1f4d-4321-4ef9-8af8-8db277767eca) | ![after](https://github.com/rails/sdoc/assets/771968/0bf377b9-1fd0-4b0d-aaee-4e05b7aa51ba) |
