### PR TITLE
Fix performance regression due to git calls

### DIFF
--- a/lib/sdoc/helpers/git.rb
+++ b/lib/sdoc/helpers/git.rb
@@ -1,4 +1,8 @@
 module SDoc::Helpers::Git
+  def _git
+    @@_git ||= {}
+  end
+
   def github_url(relative_path, line: nil)
     return unless github?
     line = "#L#{line}" if line
@@ -9,43 +13,34 @@ module SDoc::Helpers::Git
     @options.github && git? && github_repository
   end
 
-  attr_writer :git_repo_path
-
   def git?
-    @git_repo_path ||= Dir.chdir(@options.root) { `git rev-parse --show-toplevel 2> /dev/null`.chomp }
-    !@git_repo_path.empty?
+    _git[:repo_path] ||= Dir.chdir(@options.root) { `git rev-parse --show-toplevel 2> /dev/null`.chomp }
+    !_git[:repo_path].empty?
   end
 
   def git_command(command)
     Dir.chdir(@options.root) { `git #{command}`.chomp } if git?
   end
 
-  attr_writer :git_head_branch
-
   def git_head_branch
-    @git_head_branch ||= git_command("rev-parse --abbrev-ref HEAD")
+    _git[:head_branch] ||= git_command("rev-parse --abbrev-ref HEAD")
   end
-
-  attr_writer :git_head_sha1
 
   def git_head_sha1
-    @git_head_sha1 ||= git_command("rev-parse HEAD")
+    _git[:head_sha1] ||= git_command("rev-parse HEAD")
   end
-
-  attr_writer :git_head_timestamp
 
   def git_head_timestamp
-    @git_head_timestamp ||= git_command("show -s --format=%cI HEAD")
+    _git[:head_timestamp] ||= git_command("show -s --format=%cI HEAD")
   end
 
-  attr_writer :git_origin_url
-
   def git_origin_url
-    @git_origin_url ||= git_command("config --get remote.origin.url")
+    _git[:origin_url] ||= git_command("config --get remote.origin.url")
   end
 
   def github_repository
-    return @github_repository if defined?(@github_repository)
-    @github_repository = git_origin_url.chomp(".git")[%r"github\.com[/:](.+)", 1]
+    _git.fetch(:github_repository) do
+      _git[:github_repository] = git_origin_url.chomp(".git")[%r"github\.com[/:](.+)", 1]
+    end
   end
 end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -8,6 +8,7 @@ describe SDoc::Helpers do
       attr_accessor :options
     end.new
 
+    @helpers._git.clear
     @helpers.options = RDoc::Options.new
   end
 
@@ -33,9 +34,9 @@ describe SDoc::Helpers do
     end
 
     it "returns the URL for a given path in the project's GitHub repository at the current SHA1" do
-      @helpers.git_repo_path = "path/to/repo"
-      @helpers.git_origin_url = "git@github.com:user/repo.git"
-      @helpers.git_head_sha1 = "1337c0d3"
+      @helpers._git[:repo_path] = "path/to/repo"
+      @helpers._git[:origin_url] = "git@github.com:user/repo.git"
+      @helpers._git[:head_sha1] = "1337c0d3"
 
       _(@helpers.github_url("foo/bar/qux.rb")).
         must_equal "https://github.com/user/repo/blob/1337c0d3/foo/bar/qux.rb"
@@ -47,14 +48,14 @@ describe SDoc::Helpers do
     end
 
     it "supports HTTPS remote URL" do
-      @helpers.git_origin_url = "https://github.com/user/repo.git"
+      @helpers._git[:origin_url] = "https://github.com/user/repo.git"
 
       _(@helpers.github_url("foo/bar/qux.rb")).
         must_match %r"\Ahttps://github.com/user/repo/blob/[0-9a-f]{40}/foo/bar/qux\.rb\z"
     end
 
     it "supports HTTPS remote URL without .git extension" do
-      @helpers.git_origin_url = "https://github.com/user/repo"
+      @helpers._git[:origin_url] = "https://github.com/user/repo"
 
       _(@helpers.github_url("foo/bar/qux.rb")).
         must_match %r"\Ahttps://github.com/user/repo/blob/[0-9a-f]{40}/foo/bar/qux\.rb\z"
@@ -67,19 +68,19 @@ describe SDoc::Helpers do
     end
 
     it "returns nil when git is not installed or project is not a git repository" do
-      @helpers.git_repo_path = ""
+      @helpers._git[:repo_path] = ""
 
       _(@helpers.github_url("foo/bar/qux.rb")).must_be_nil
     end
 
     it "returns nil when 'origin' remote is not present" do
-      @helpers.git_origin_url = ""
+      @helpers._git[:origin_url] = ""
 
       _(@helpers.github_url("foo/bar/qux.rb")).must_be_nil
     end
 
     it "returns nil when 'origin' remote is not recognized" do
-      @helpers.git_origin_url = "git@gitlab.com:user/repo.git"
+      @helpers._git[:origin_url] = "git@gitlab.com:user/repo.git"
 
       _(@helpers.github_url("foo/bar/qux.rb")).must_be_nil
     end
@@ -383,9 +384,9 @@ describe SDoc::Helpers do
 
   describe "#project_git_head" do
     it "returns the branch name and abbreviated SHA1 of the most recent commit in HEAD" do
-      @helpers.git_repo_path = "path/to/repo"
-      @helpers.git_head_branch = "1-0-stable"
-      @helpers.git_head_sha1 = "1337c0d3d00d" * 3
+      @helpers._git[:repo_path] = "path/to/repo"
+      @helpers._git[:head_branch] = "1-0-stable"
+      @helpers._git[:head_sha1] = "1337c0d3d00d" * 3
 
       _(@helpers.project_git_head).must_equal "1-0-stable@1337c0d3d00d"
     end
@@ -395,7 +396,7 @@ describe SDoc::Helpers do
     end
 
     it "returns nil when git is not installed or project is not a git repository" do
-      @helpers.git_repo_path = ""
+      @helpers._git[:repo_path] = ""
 
       _(@helpers.project_git_head).must_be_nil
     end
@@ -444,8 +445,8 @@ describe SDoc::Helpers do
 
   describe "#og_modified_time" do
     it "returns the commit time of the most recent commit in HEAD" do
-      @helpers.git_repo_path = "path/to/repo"
-      @helpers.git_head_timestamp = "1999-12-31T12:34:56Z"
+      @helpers._git[:repo_path] = "path/to/repo"
+      @helpers._git[:head_timestamp] = "1999-12-31T12:34:56Z"
 
       _(@helpers.og_modified_time).must_equal "1999-12-31T12:34:56Z"
     end
@@ -456,7 +457,7 @@ describe SDoc::Helpers do
     end
 
     it "returns nil when git is not installed or project is not a git repository" do
-      @helpers.git_repo_path = ""
+      @helpers._git[:repo_path] = ""
 
       _(@helpers.og_modified_time).must_be_nil
     end


### PR DESCRIPTION
In d08ca4d758f2633b9a2a49a045d56d4856c2e5e4, an isolated scope was created for each rendered file.  That inadvertently reset memoized values from `git` calls for each file, causing a performance regression.

This commit fixes the regression by memoizing the values globally.

With d08ca4d758f2633b9a2a49a045d56d4856c2e5e4~1 (444c4a46211d305353485f21012c3c242104b0e4):

  ```console
  $ time bundle exec rake test:rails
  real  0m31.567s
  user  0m31.159s
  sys 0m0.394s
  ```

With d08ca4d758f2633b9a2a49a045d56d4856c2e5e4:

  ```console
  $ time bundle exec rake test:rails
  real  1m11.195s
  user  1m2.671s
  sys 0m8.811s
  ```
With d08ca4d758f2633b9a2a49a045d56d4856c2e5e4 + this commit (retrofitted):

  ```console
  $ time bundle exec rake test:rails
  real  0m26.155s
  user  0m25.796s
  sys 0m0.331s
  ```

With `main`:

  ```console
  $ time bundle exec rake test:rails
  real  1m16.000s
  user  1m7.478s
  sys 0m8.818s
```

With `main` + this commit:

  ```console
  $ time bundle exec rake test:rails
  real  0m29.964s
  user  0m29.562s
  sys 0m0.399s
  ```

Fixes #361.
