### PR TITLE
Make Rack 3 work OOTB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rack"
+gem "rack", "~> 3.0"
 gem "rake"
 gem "hoe"
 gem "minitest"
@@ -14,4 +14,3 @@ end
 
 gem "importmap-rails"
 gem "railties"
-

--- a/README.md
+++ b/README.md
@@ -70,20 +70,20 @@ Please feel free to still report issues here for both projects, especially if yo
 If you'd like to contribute you can generate the Rails main branch documentation by running:
 
 ```bash
-rake test:rails
+bundle exec rake test:rails
 ```
 
 You can generate the Ruby default branch documentation by running:
 
 ```bash
-rake test:ruby
+bundle exec rake test:ruby
 ```
 
 The generated documentation will be put into `doc/public` directory.
 To view the just generated documentation start up a rack application by running:
 
 ```bash
-rackup config.ru
+bundle exec rackup config.ru
 ```
 
 Then open http://localhost:9292 in the browser to view the documentation.

--- a/config.ru
+++ b/config.ru
@@ -15,6 +15,7 @@ unless Dir.exist?(root)
   exit
 end
 
+require "rack/static"
 use Rack::Static,
   :urls => ["/files", "/images", "/js", "/css", "/panel", "/i", "/fonts", "/classes", "/ruby", "/rails"],
   :root => root
@@ -22,8 +23,8 @@ run lambda { |env|
   [
     200,
     {
-      'Content-Type'  => 'text/html',
-      'Cache-Control' => 'public, max-age=86400'
+      'content-type'  => 'text/html',
+      'cache-control' => 'public, max-age=86400'
     },
     File.open("#{root}/index.html", File::RDONLY)
   ]


### PR DESCRIPTION
* Rack::Static is not autoloaded anymore
* Headers must be lowercase (not sure where Rack::Lint is coming from)

I prepend `bundle exec` to commands because I end up activating rack 2.2.9 beforehand otherwise.

This _probably_ still works with rack 2 as well but does it have to? Closes #366