### PR TITLE
Add attributes to the search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Main (3.0.0.alpha)
 * [#356](https://github.com/rails/sdoc/pull/356) Redesign "Constants" section [@jonathanhefner](https://github.com/jonathanhefner)
 * [#357](https://github.com/rails/sdoc/pull/357) Support permalinking constants [@jonathanhefner](https://github.com/jonathanhefner)
 * [#358](https://github.com/rails/sdoc/pull/358) Add constants to search index [@jonathanhefner](https://github.com/jonathanhefner)
+* [#370](https://github.com/rails/sdoc/pull/370) Add attributes to search index [@earlopain](https://github.com/earlopain)
 
 2.6.1
 =====

--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -77,7 +77,7 @@
       <h2 class="content__divider">Attributes</h2>
       <table border='0' cellpadding='5'>
         <% attributes.each do |attrib| %>
-          <tr valign='top'>
+          <tr valign='top' id='<%= attrib.aref %>'>
             <td class='attr-rw'>
               [<%= attrib.rw %>]
             </td>

--- a/lib/sdoc/search_index.rb
+++ b/lib/sdoc/search_index.rb
@@ -13,7 +13,10 @@ module SDoc::SearchIndex
   end
 
   def generate(rdoc_modules)
-    rdoc_objects = rdoc_modules + rdoc_modules.flat_map(&:constants) + rdoc_modules.flat_map(&:method_list)
+    rdoc_objects = rdoc_modules +
+      rdoc_modules.flat_map(&:constants) +
+      rdoc_modules.flat_map(&:method_list) +
+      rdoc_modules.flat_map(&:attributes)
 
     # RDoc duplicates member instances when modules are aliased by assigning to
     # a constant. For example, `MyBar = Foo::Bar` will duplicate all of


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5ff31ff1-82b9-4c80-898d-91b072d8b87d) | ![image](https://github.com/user-attachments/assets/d79a31f8-dee2-4138-99dc-c2654113304d) | 

To make this work correctly, add anchors to the generated html.

RDoc uses the same class for methods and attributes so most of the plumbing was already there.

Closes #369. I oriented myself with https://github.com/rails/sdoc/pull/358 which is the PR for adding constants to the search.