### PR TITLE
Import rails guides color theme for dark mode

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -76,12 +76,13 @@ body {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --text-color: #dddddd;
-    --link-color: #ee3f3f;
+    --text-color: #e5e5e5;
+    --link-color: #f06b6e;
+    --link-hover-color: #ec3d41;
 
-    --body-bg: #0c0c0c;
-    --code-bg: #1b1b1b;
-    --source-code-bg: #000000;
+    --body-bg: #181818;
+    --code-bg: #292929;
+    --source-code-bg: #292929;
   }
 }
 


### PR DESCRIPTION
Colors are from https://github.com/rails/rails/blob/59566cab94ca2f5c43147117870f0ee0ff73fed3/guides/assets/stylesrc/style.scss

* The current background is _very_ dark
* Hovered links used to be white
* Better contrast on code blocks

Before:
![grafik](https://github.com/user-attachments/assets/2a94b505-a926-4369-8756-059ac5ba4018)

After:
![grafik](https://github.com/user-attachments/assets/9d401cc2-fed7-4672-8e93-c7a1747cd98e)
