### PR TITLE
Display section comments

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -52,7 +52,7 @@
       </div>
     <% end %>
 
-    <%= description_for section %>
+    <%= comments_for @context, section %>
 
     <!-- Constants -->
     <% unless constants.empty? %>

--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -64,6 +64,12 @@ module SDoc::Helpers
     end
   end
 
+  def comments_for(context, section)
+    return if section.comments.empty?
+
+    %(<div class="description">#{context.markup section.comments}</div>)
+  end
+
   def base_tag_for_context(context)
     relative_root = "../" * context.path.count("/")
     %(<base href="./#{relative_root}" data-current-path="#{context.path}">)

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -300,6 +300,39 @@ describe SDoc::Helpers do
     end
   end
 
+  describe "#comments_for" do
+    it "returns RDoc::Context::Section#comments wrapped in div.description" do
+      rdoc_module = rdoc_top_level_for(<<~RUBY).find_module_named("Foo")
+        module Foo
+          # :section: Section 1
+          # First comment for Section 1 in Foo.
+
+          # :section: Section 1
+          # Second comment for Section 1 in Foo.
+        end
+      RUBY
+
+      _(@helpers.comments_for(rdoc_module, rdoc_module.sections.last)).
+        must_equal <<~HTML.chomp
+          <div class="description">
+          <p>First comment for Section 1 in <code>Foo</code>.</p>
+
+          <p>Second comment for Section 1 in <code>Foo</code>.</p>
+          </div>
+        HTML
+    end
+
+    it "returns nil when RDoc::CodeObject#description is empty" do
+      rdoc_module = rdoc_top_level_for(<<~RUBY).find_module_named("Foo")
+        module Foo
+          # :section: One
+        end
+      RUBY
+
+      _(@helpers.comments_for(rdoc_module, rdoc_module.sections.last)).must_be_nil
+    end
+  end
+
   describe "#base_tag_for_context" do
     it "returns a <base> tag with an appropriate path for the given RDoc::Context" do
       top_level = rdoc_top_level_for <<~RUBY


### PR DESCRIPTION
This PR addresses an issue resulting from RDoc having changed where comments are stored in sections (since https://github.com/ruby/rdoc/commit/4b50423ec36298d9dd75f05b6df31463db264508 as an array at `RDoc::Context::Section#comments`) without removing the old reader. This can make it seem like `#comment` is still available as with other RDoc objects, when in reality for sections it now never has a value. This then means `#description` doesn't work for sections, because it calls the old reader. I couldn't find any tests in the RDoc repo suggesting how `#comments` is supposed to be formatted, so this was just a guess