### PR TITLE
Fix compatibility with RDoc >= 6.10.0

### DIFF
--- a/lib/sdoc/rdoc_monkey_patches.rb
+++ b/lib/sdoc/rdoc_monkey_patches.rb
@@ -32,7 +32,7 @@ end)
 
 
 RDoc::Markup::ToHtmlCrossref.prepend(Module.new do
-  def cross_reference(name, text = nil, code = true)
+  def cross_reference(name, text = nil, code = true, *, **)
     if text
       # Style ref links that look like code, such as `{Rails}[rdoc-ref:Rails]`.
       code ||= !text.include?(" ") || text.match?(/\S\(/)


### PR DESCRIPTION
ruby/rdoc@4a5206ae564fb6c3ba78e200b776001785c30839 added a kwarg to `RDoc::Markup::ToHtmlCrossref#cross_reference` which must be forwarded.

This commit adds a double-splat (`**`) to the `cross_reference` monkey patch in order to forward that kwarg.  It also adds a splat (`*`) in case more positional args with default values are added in the future.