### PR TITLE
Fix compatibility with RDoc 6.13.0

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -25,9 +25,6 @@ class RDoc::Generator::SDoc
 
   DESCRIPTION = 'Searchable HTML documentation'
 
-  FILE_DIR = 'files'
-  CLASS_DIR = 'classes'
-
   RESOURCES_DIR = File.join('resources', '.')
 
   attr_reader :options
@@ -94,11 +91,11 @@ class RDoc::Generator::SDoc
   end
 
   def class_dir
-    CLASS_DIR
+    nil
   end
 
   def file_dir
-    FILE_DIR
+    nil
   end
 
   ### Determines index page based on @options.main_page (or lack thereof)

--- a/lib/sdoc/rdoc_monkey_patches.rb
+++ b/lib/sdoc/rdoc_monkey_patches.rb
@@ -1,6 +1,20 @@
 require "rdoc"
 
 RDoc::TopLevel.prepend(Module.new do
+  def path
+    File.join("files", super)
+  end
+end)
+
+
+RDoc::ClassModule.prepend(Module.new do
+  def path
+    File.join("classes", super)
+  end
+end)
+
+
+RDoc::TopLevel.prepend(Module.new do
   attr_writer :path
 
   def path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ def rdoc_top_level_for(ruby_code)
   # foolproof way to initialize it is by simply running it with a dummy file.
   $rdoc_for_specs ||= rdoc_dry_run("--files", __FILE__)
 
-  $rdoc_for_specs.store = RDoc::Store.new
+  $rdoc_for_specs.store = RDoc::Store.new(RDoc::Options.new)
 
   Dir.mktmpdir do |dir|
     path = "#{dir}/ruby_code.rb"


### PR DESCRIPTION
This PR addresses two issues with RDoc 6.13.0:

* ruby/rdoc@694987be2bc244ceb4686ee75a1272cc9e27313c removed support for `file_dir` and `class_dir`, which we use to prefix URL paths with `files/` or `classes/` (for example, in the URLs for https://api.rubyonrails.org/files/activerecord/lib/active_record/base_rb.html and https://api.rubyonrails.org/classes/ActiveRecord/Base.html).

* ruby/rdoc@f517b028c6e5957fb546aa619559dca3abf05993 changed the signature of `RDoc::Store#initialize` from `initialize(path = nil, type = nil)` to `initialize(options, path: nil, type: nil)`, which is a breaking change.
