### PR TITLE
Use `{class_module,file}_path_prefix` RDoc options

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -25,6 +25,9 @@ class RDoc::Generator::SDoc
 
   DESCRIPTION = 'Searchable HTML documentation'
 
+  FILE_DIR = "files"
+  CLASS_DIR = "classes"
+
   RESOURCES_DIR = File.join('resources', '.')
 
   attr_reader :options
@@ -63,6 +66,14 @@ class RDoc::Generator::SDoc
       ENV["HORO_BADGE_VERSION"] || ENV["HORO_PROJECT_VERSION"],
       "API documentation"
     ].compact.join(" ")
+
+    if options.respond_to?(:class_module_path_prefix)
+      options.class_module_path_prefix = CLASS_DIR
+    end
+
+    if options.respond_to?(:file_path_prefix)
+      options.file_path_prefix = FILE_DIR
+    end
   end
 
   def initialize(store, options)
@@ -90,12 +101,14 @@ class RDoc::Generator::SDoc
     generate_class_files
   end
 
+  # For compatibility with RDoc < 6.13.0
   def class_dir
-    nil
+    CLASS_DIR
   end
 
+  # For compatibility with RDoc < 6.13.0
   def file_dir
-    nil
+    FILE_DIR
   end
 
   ### Determines index page based on @options.main_page (or lack thereof)

--- a/lib/sdoc/rdoc_monkey_patches.rb
+++ b/lib/sdoc/rdoc_monkey_patches.rb
@@ -1,20 +1,6 @@
 require "rdoc"
 
 RDoc::TopLevel.prepend(Module.new do
-  def path
-    File.join("files", super)
-  end
-end)
-
-
-RDoc::ClassModule.prepend(Module.new do
-  def path
-    File.join("classes", super)
-  end
-end)
-
-
-RDoc::TopLevel.prepend(Module.new do
   attr_writer :path
 
   def path

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -453,7 +453,7 @@ describe SDoc::Helpers do
 
     it "returns the commit time of the most recent commit in HEAD (smoke test)" do
       _(@helpers.og_modified_time).
-        must_match %r"\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}\z"
+        must_match %r"\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[-+]\d{2}:\d{2})\z"
     end
 
     it "returns nil when git is not installed or project is not a git repository" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ def rdoc_top_level_for(ruby_code)
   # foolproof way to initialize it is by simply running it with a dummy file.
   $rdoc_for_specs ||= rdoc_dry_run("--files", __FILE__)
 
-  $rdoc_for_specs.store = RDoc::Store.new(RDoc::Options.new)
+  $rdoc_for_specs.store = RDoc::Store.new($rdoc_for_specs.options)
 
   Dir.mktmpdir do |dir|
     path = "#{dir}/ruby_code.rb"


### PR DESCRIPTION
Follow-up to #375.

RDoc 6.13.1 has been released, and includes support for the `class_module_path_prefix` and `file_path_prefix` options (added in ruby/rdoc@3bc179ddfb74b46c52f697b9d1ce331264fcd84c), which serve as replacements for the `class_dir` and `file_dir` methods.

This commit removes the RDoc monkey patch added in e2d849f48cb2ed3effe39a674ca79de7e8fb812b in favor of using those options.  This means SDoc will be incompatible with RDoc 6.13.0 specifically, but that shouldn't be a significant issue (and compatibility with RDoc < 6.13.0 is preserved).