### PR TITLE
Remove last_modified from documentation index

### DIFF
--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -22,7 +22,6 @@
         </h2>
         <ul class="files">
             <li><%= h index.relative_name %></li>
-            <li>Last modified: <%= index.last_modified %></li>
         </ul>
         <% if ENV['HORO_BADGE_VERSION'] %>
             <div id="version-badge"><%= ENV['HORO_BADGE_VERSION'] %></div>


### PR DESCRIPTION
Ref https://github.com/ruby/rdoc/pull/1315
Ref #275

The method was removed from RDoc, so this change fixes compatibility with RDoc 6.13.0+

(The line was also removed from edge sdoc already because the value displayed doesn't really make since: it's the last_modified time of the Rails README.md and not anything to do with documentation generation)

cc @rafaelfranca 