### PR TITLE
Remove last_modified from sdoc template

### DIFF
--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -103,7 +103,7 @@
       <!-- Section constants -->
       <div class="sectiontitle">Constants</div>
       <table border='0' cellpadding='5'>
-        <% context.each_constant do |const| %>
+        <% constants.each do |const| %>
           <tr valign='top'>
             <td class="attr-name"><%= h const.name %></td>
             <td>=</td>

--- a/lib/rdoc/generator/template/sdoc/file.rhtml
+++ b/lib/rdoc/generator/template/sdoc/file.rhtml
@@ -17,7 +17,6 @@
         </h1>
         <ul class="files">
             <li><%= h file.relative_name %></li>
-            <li>Last modified: <%= file.last_modified %></li>
         </ul>
     </div>
 


### PR DESCRIPTION
Copies ead9de6 for the sdoc template.
Note, this template was removed in 3000a97 from main (unstable 3.x branch).

Fixes #380